### PR TITLE
rename 3dt -> dcos-diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-PLATFORM := $(shell uname)
-REV := $(shell git rev-parse --short HEAD)
-LDFLAGS := -X github.com/dcos/3dt/api.Revision=$(REV)
-
 all: test install
 
 test:
@@ -18,4 +14,4 @@ install:
 	go install -v -ldflags '$(LDFLAGS)'
 
 clean:
-	rm -f ./3dt
+	rm -f ./dcos-diagnostics

--- a/README.md
+++ b/README.md
@@ -1,42 +1,42 @@
-# 3DT [![velocity](https://jenkins.mesosphere.com/service/jenkins/buildStatus/icon?job=public-dcos-3dt-pulls)](https://velocity.mesosphere.com/service/jenkins/view/DCOS/job/public-dcos-3dt-pulls/)
+# dcos-diagnostics [![velocity](https://jenkins.mesosphere.com/service/jenkins/buildStatus/icon?job=public-dcos-diagnostics-pulls)](https://velocity.mesosphere.com/service/jenkins/view/DCOS/job/public-dcos-diagnostics-pulls/)
 ## DC/OS Distributed Diagnostics Tool & Aggregation Service
-3DT is a monitoring agent which exposes a HTTP API for querying from the /system/health/v1 DC/OS api. 3DT puller collects the data from 3dt agents and represents individual node health for things like system resources as well as DC/OS-specific services.
+dcos-diagnostics is a monitoring agent which exposes a HTTP API for querying from the /system/health/v1 DC/OS api. dcos-diagnostics puller collects the data from agents and represents individual node health for things like system resources as well as DC/OS-specific services.
 
 ## Build
 
 ```
-go get github.com/dcos/3dt
-cd $GOPATH/src/github.com/dcos/3dt
+go get github.com/dcos/dcos-diagnostics
+cd $GOPATH/src/github.com/dcos/dcos-diagnostics
 make install
-./3dt --version
+./dcos-diagnostics --version
 ```
 
 ## Run
-Run 3DT once, on a DC/OS host to check systemd units:
+Run dcos-diagnostics once, on a DC/OS host to check systemd units:
 
 ```
-3dt --diag
+dcos-diagnostics --diag
 ```
 
 Get verbose log output:
 
 ```
-3dt --diag --verbose
+dcos-diagnostics --diag --verbose
 ```
 
-Run the 3DT aggregation service to query all cluster hosts for health state:
+Run the dcos-diagnostics aggregation service to query all cluster hosts for health state:
 
 ```
-3dt daemon --pull
+dcos-diagnostics daemon --pull
 ```
 
-Start the 3DT health API endpoint:
+Start the dcos-diagnostics health API endpoint:
 
 ```
-3dt daemon
+dcos-diagnostics daemon
 ```
 
-### 3DT daemon options
+### dcos-diagnostics daemon options
 
 <pre>
 --agent-port int
@@ -52,7 +52,7 @@ Start the 3DT health API endpoint:
     Get diagnostics output once on the CLI. Does not expose API.
 
 --diagnostics-bundle-dir string
-    Set a path to store diagnostic bundles (default "/var/run/dcos/3dt/diagnostic_bundles")
+    Set a path to store diagnostic bundles (default "/var/run/dcos/dcos-diagnostics/diagnostic_bundles")
 
 --diagnostics-job-timeout int
     Set a global diagnostics job timeout (default 720)
@@ -98,7 +98,7 @@ Start the 3DT health API endpoint:
 </pre>
 
 
-## 3dt checks options
+## dcos-diagnostics checks options
 TBD
 
 ## Test

--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/dcos/3dt/config"
+	"github.com/dcos/dcos-diagnostics/config"
 	"github.com/dcos/dcos-go/exec"
 	"github.com/shirou/gopsutil/disk"
 )
@@ -795,11 +795,11 @@ func loadInternalProviders(cfg *config.Config, DCOSTools DCOSHelper) (internalCo
 		})
 	}
 
-	// add 3dt health report.
+	// add dcos-diagnostics health report.
 	httpEndpoints = append(httpEndpoints, HTTPProvider{
 		Port:     port,
 		URI:      BaseRoute,
-		FileName: "3dt-health.json",
+		FileName: "dcos-diagnostics-health.json",
 	})
 
 	return LogProviders{

--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/mux"
-	assertPackage "github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/gorilla/mux"
+	assertPackage "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 type DiagnosticsTestSuit struct {
@@ -235,7 +236,7 @@ func (s *DiagnosticsTestSuit) TestCancelGlobalJob() {
 	mockedResponse := `{"10.0.7.252":{"is_running":false}}`
 
 	mockedMasters := []Node{
-		Node{
+		{
 			Role: "master",
 			IP:   "10.0.7.252",
 		},

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -23,7 +23,7 @@ func httpError(w http.ResponseWriter, msg string, code int) {
 }
 
 // Route handlers
-// /api/v1/system/health, get a units status, used by 3dt puller
+// /api/v1/system/health, get a units status, used by dcos-diagnostics puller
 func unitsHealthStatus(w http.ResponseWriter, r *http.Request) {
 	dt, ok := getDtFromContext(r.Context())
 	if !ok {

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dcos/3dt/config"
+	"github.com/dcos/dcos-diagnostics/config"
 	"github.com/gorilla/mux"
 	assertPackage "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -146,7 +146,7 @@ func (st *fakeDCOSTools) Get(url string, timeout time.Duration) (body []byte, st
 			  "dcos_version":"1.6",
 			  "node_role":"master",
 			  "mesos_id":"master-123",
-			  "3dt_version": "0.0.7"
+			  "dcos_diagnostics_version": "0.0.7"
 			}`
 	}
 
@@ -177,7 +177,7 @@ func (st *fakeDCOSTools) Get(url string, timeout time.Duration) (body []byte, st
 			  "dcos_version":"1.6",
 			  "node_role":"agent",
 			  "mesos_id":"agent-123",
-			  "3dt_version": "0.0.7"
+			  "dcos_diagnostics_version": "0.0.7"
 			}`
 	}
 	return []byte(response), 200, nil
@@ -259,7 +259,7 @@ func (s *HandlersTestSuit) SetupTest() {
 				UnitID:     "dcos-ddt.service",
 				UnitHealth: 0,
 				UnitTitle:  "Diag service",
-				PrettyName: "3dt",
+				PrettyName: "dcos-diagnostics",
 			},
 		},
 		Hostname:    "localhost",

--- a/api/health.go
+++ b/api/health.go
@@ -1,14 +1,14 @@
 package api
 
 import (
+	"os"
 	"sync"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/dcos/3dt/config"
+	"github.com/dcos/dcos-diagnostics/config"
 	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/load"
 	"github.com/shirou/gopsutil/mem"
-	"os"
 )
 
 // SystemdUnits used to make GetUnitsProperties thread safe.

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// _SYSTEMD_UNIT and UNIT are custom fields used by systemd to mark logs by the systemd unit itself and
-	// also by other related components. When 3dt reads log entries it needs to filter both entries.
+	// also by other related components. When dcos-diagnostics reads log entries it needs to filter both entries.
 	systemdUnitProperty = "_SYSTEMD_UNIT"
 	unitProperty        = "UNIT"
 )

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/dcos/3dt/config"
+	"github.com/dcos/dcos-diagnostics/config"
 )
 
 // HTTPRequester is an interface to make HTTP requests

--- a/api/pull.go
+++ b/api/pull.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/dcos/3dt/config"
+	"github.com/dcos/dcos-diagnostics/config"
 	"github.com/dcos/dcos-go/dcos"
 )
 
@@ -393,7 +393,7 @@ func (mr *MonitoringResponse) GetMasterAgentNodes() ([]Node, []Node, error) {
 	}
 
 	if len(masterNodes) == 0 && len(agentNodes) == 0 {
-		return masterNodes, agentNodes, errors.New("No nodes found in memory, perhaps 3dt was started without -pull flag")
+		return masterNodes, agentNodes, errors.New("No nodes found in memory, perhaps dcos-diagnostics was started without -pull flag")
 	}
 
 	return masterNodes, agentNodes, nil

--- a/api/pull_test.go
+++ b/api/pull_test.go
@@ -1,11 +1,11 @@
 package api
 
 import (
-	// intentionally rename package to do some magic
-	assertPackage "github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"sync"
 	"testing"
+
+	assertPackage "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 type PullerTestSuit struct {

--- a/api/router.go
+++ b/api/router.go
@@ -16,7 +16,7 @@ type key int
 
 var dtKey key = 1
 
-// BaseRoute a base 3dt endpoint location.
+// BaseRoute a base dcos-diagnostics endpoint location.
 const BaseRoute string = "/system/health/v1"
 
 type routeHandler struct {
@@ -69,7 +69,7 @@ func noCacheMiddleware(next http.Handler, dt *Dt) http.Handler {
 		}
 
 		if !dt.Cfg.FlagPull {
-			e := "3dt was not started with -pull flag"
+			e := "dcos-diagnostics was not started with -pull flag"
 			logrus.Error(e)
 			http.Error(w, e, http.StatusServiceUnavailable)
 			return

--- a/api/structures.go
+++ b/api/structures.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dcos/3dt/config"
+	"github.com/dcos/dcos-diagnostics/config"
 	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/load"
 	"github.com/shirou/gopsutil/mem"
@@ -57,7 +57,7 @@ type UnitsHealthResponseJSONStruct struct {
 	DcosVersion string                 `json:"dcos_version"`
 	Role        string                 `json:"node_role"`
 	MesosID     string                 `json:"mesos_id"`
-	TdtVersion  string                 `json:"3dt_version"`
+	TdtVersion  string                 `json:"dcos_diagnostics_version"`
 }
 
 // HealthResponseValues is a health values json response.
@@ -128,7 +128,7 @@ type exhibitorNodeResponse struct {
 	IsLeader    bool
 }
 
-// Dt is a struct of dependencies used in 3dt code. There are 2 implementations, the one runs on a real system and
+// Dt is a struct of dependencies used in dcos-diagnostics code. There are 2 implementations, the one runs on a real system and
 // the one used for testing.
 type Dt struct {
 	Cfg               *config.Config

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -21,7 +21,7 @@ import (
 	"os"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/dcos/3dt/runner"
+	"github.com/dcos/dcos-diagnostics/runner"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +30,7 @@ const (
 	checkTypeNodePreStart  = "node-prestart"
 	checkTypeNodePostStart = "node-poststart"
 
-	defaultRunnerConfig    = "/opt/mesosphere/etc/dcos-3dt-runner-config.json"
+	defaultRunnerConfig    = "/opt/mesosphere/etc/dcos-diagnostics-runner-config.json"
 )
 
 var (

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/coreos/go-systemd/activation"
-	"github.com/dcos/3dt/api"
+	"github.com/dcos/dcos-diagnostics/api"
 	"github.com/dcos/dcos-go/dcos"
 	"github.com/dcos/dcos-go/dcos/http/transport"
 	"github.com/dcos/dcos-go/dcos/nodeutil"
@@ -32,7 +32,7 @@ import (
 
 const (
 	diagnosticsTCPPort        = 1050
-	diagnosticsBundleDir      = "/var/run/dcos/3dt/diagnostic_bundles"
+	diagnosticsBundleDir      = "/var/run/dcos/dcos-diagnostics/diagnostic_bundles"
 	diagnosticsEndpointConfig = "/opt/mesosphere/etc/endpoints_config.json"
 	exhibitorURL              = "http://127.0.0.1:8181/exhibitor/v1/cluster/status"
 )
@@ -150,7 +150,7 @@ func startDiagnosticsDaemon() {
 		logrus.Fatalf("Could not init diagnostics job properly: %s", err)
 	}
 
-	// Inject dependencies used for running 3dt.
+	// Inject dependencies used for running dcos-diagnostics.
 	dt := &api.Dt{
 		Cfg:               defaultConfig,
 		DtDCOSTools:       DCOSTools,
@@ -162,7 +162,7 @@ func startDiagnosticsDaemon() {
 	}
 
 	// start diagnostic server and expose endpoints.
-	logrus.Info("Start 3DT")
+	logrus.Info("Start dcos-diagnostics")
 
 	// start pulling every 60 seconds.
 	if defaultConfig.FlagPull {
@@ -172,7 +172,7 @@ func startDiagnosticsDaemon() {
 	router := api.NewRouter(dt)
 
 	if defaultConfig.FlagDisableUnixSocket {
-		logrus.Infof("Exposing 3DT API on 0.0.0.0:%d", defaultConfig.FlagPort)
+		logrus.Infof("Exposing dcos-diagnostics API on 0.0.0.0:%d", defaultConfig.FlagPort)
 		logrus.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", defaultConfig.FlagPort), router))
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,8 +19,8 @@ import (
 	"os"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/dcos/3dt/api"
-	"github.com/dcos/3dt/config"
+	"github.com/dcos/dcos-diagnostics/api"
+	"github.com/dcos/dcos-diagnostics/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -34,12 +34,12 @@ var (
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
-	Use:   "3dt",
+	Use:   "dcos-diagnostics",
 	Short: "DC/OS diagnostics service",
 	Long: `DC/OS diagnostics service provides health information about cluster.
 
-3dt daemon start an http server and polls the components health.
-3dt check provides CLI functionality to run checks on DC/OS cluster.
+dcos-diagnostics daemon start an http server and polls the components health.
+dcos-diagnostics check provides CLI functionality to run checks on DC/OS cluster.
 `,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
@@ -68,8 +68,8 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	RootCmd.PersistentFlags().BoolVar(&version, "version", false, "Print 3dt version")
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.3dt.yaml)")
+	RootCmd.PersistentFlags().BoolVar(&version, "version", false, "Print dcos-diagnostics version")
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.dcos-diagnostics.yaml)")
 	RootCmd.PersistentFlags().BoolVar(&diag, "diag", false,
 		"Check DC/OS components health.")
 	RootCmd.PersistentFlags().BoolVar(&defaultConfig.FlagVerbose, "verbose", defaultConfig.FlagVerbose,
@@ -80,7 +80,7 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	viper.SetConfigName("dcos-3dt-config") // name of config file (without extension)
+	viper.SetConfigName("dcos-diagnostics-config") // name of config file (without extension)
 	viper.AddConfigPath("/opt/mesosphere/etc/")
 	viper.AutomaticEnv()
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	// Version of 3dt code.
+	// Version of dcos-diagnostics code.
 	Version = "0.4.0"
 
 	// APIVer is an API version.
@@ -17,7 +17,7 @@ var (
 type Config struct {
 	SystemdUnits []string `json:"-"`
 
-	// 3dt flags
+	// dcos-diagnostics flags
 	FlagCACertFile                 string `json:"ca-cert"`
 	FlagPull                       bool   `json:"pull"`
 	FlagVerbose                    bool   `json:"verbose"`

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/dcos/3dt/cmd"
+	"github.com/dcos/dcos-diagnostics/cmd"
 )
 
 func main() {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -336,5 +336,5 @@
 			"revisionTime": "2017-04-07T17:21:22Z"
 		}
 	],
-	"rootPath": "github.com/dcos/3dt"
+	"rootPath": "github.com/dcos/dcos-diagnostics"
 }


### PR DESCRIPTION
rename `3dt` to `dcos-diagnostics`

  - replace all `3dt` occurrence in the code
  - remove unused flags from `Makefile`