### PR TITLE
Respect PATH env var when looking for check executables

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -57,6 +57,11 @@ var checkCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		// Set up environment for running check commands.
+		for k, v := range r.CheckEnv {
+			os.Setenv(k, v)
+		}
+
 		var (
 			rs  *runner.CombinedResponse
 			err error

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -30,7 +30,7 @@ const (
 	checkTypeNodePreStart  = "node-prestart"
 	checkTypeNodePostStart = "node-poststart"
 
-	defaultRunnerConfig    = "/opt/mesosphere/etc/dcos-diagnostics-runner-config.json"
+	defaultRunnerConfig = "/opt/mesosphere/etc/dcos-diagnostics-runner-config.json"
 )
 
 var (
@@ -42,7 +42,7 @@ var (
 var checkCmd = &cobra.Command{
 	Use:   "check <check-type>",
 	Short: "Execute a DC/OS check",
-	Long: `A DC/OS check can be one of the following types: cluster, node-prestart, node-poststart`,
+	Long:  `A DC/OS check can be one of the following types: cluster, node-prestart, node-poststart`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var selectiveChecks []string
 		if len(args) == 0 {

--- a/runner/check.go
+++ b/runner/check.go
@@ -26,7 +26,7 @@ type Check struct {
 }
 
 // Run executes the given check.
-func (c *Check) Run(ctx context.Context, role string, env []string) ([]byte, int, error) {
+func (c *Check) Run(ctx context.Context, role string) ([]byte, int, error) {
 	if !c.verifyRole(role) {
 		return nil, -1, errors.Errorf("check can be executed on a node with the following roles %s. Current role %s", c.Roles, role)
 	}
@@ -44,9 +44,7 @@ func (c *Check) Run(ctx context.Context, role string, env []string) ([]byte, int
 	newCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(newCtx, c.Cmd...)
-	cmd.Env = env
-	stdout, stderr, code, err := exec.FullOutput(cmd)
+	stdout, stderr, code, err := exec.FullOutput(exec.CommandContext(newCtx, c.Cmd...))
 	if err != nil {
 		return nil, -1, err
 	}

--- a/runner/check_test.go
+++ b/runner/check_test.go
@@ -12,7 +12,7 @@ func TestCombinedOutput(t *testing.T) {
 		Roles: []string{"master"},
 	}
 
-	output, code, err := ch1.Run(context.TODO(), "master", nil)
+	output, code, err := ch1.Run(context.TODO(), "master")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/dcos/dcos-go/dcos"
@@ -233,7 +232,6 @@ func (r *Runner) run(ctx context.Context, checkMap map[string]*Check, list bool,
 	}
 
 	// main loop to get the checks info.
-	env := r.checkEnv()
 	for _, name := range currentCheckList {
 		resp := &Response{
 			name: name,
@@ -267,7 +265,7 @@ func (r *Runner) run(ctx context.Context, checkMap map[string]*Check, list bool,
 		if !list {
 
 			start := time.Now()
-			combinedOutput, code, err = currentCheck.Run(ctx, r.role, env)
+			combinedOutput, code, err = currentCheck.Run(ctx, r.role)
 			checkDuration = time.Since(start).String()
 		}
 
@@ -289,24 +287,4 @@ func (r *Runner) run(ctx context.Context, checkMap map[string]*Check, list bool,
 	}
 
 	return combinedResponse, nil
-}
-
-// checkEnv returns the runner's environment overwritten with env vars from the "check_env" config param.
-func (r *Runner) checkEnv() []string {
-	// Collect the current environment and overwrite it with env vars from config.
-	envMap := make(map[string]string)
-	for _, envVar := range os.Environ() {
-		kv := strings.SplitN(envVar, "=", 2)
-		envMap[kv[0]] = kv[1]
-	}
-	for k, v := range r.CheckEnv {
-		envMap[k] = v
-	}
-
-	// Return the environment as a string array.
-	env := []string{}
-	for k, v := range envMap {
-		env = append(env, strings.Join([]string{k, v}, "="))
-	}
-	return env
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -36,9 +36,6 @@ func TestRun(t *testing.T) {
 	r := NewRunner("master")
 	cfg := `
 {
-  "check_env": {
-    "FOO": "bar"
-  },
   "cluster_checks": {
     "test_check": {
       "cmd": ["./fixture/combined.sh"],
@@ -54,14 +51,10 @@ func TestRun(t *testing.T) {
       "check2": {
         "cmd": ["./fixture/combined.sh"],
         "timeout": "1s"
-      },
-      "check3": {
-        "cmd": ["printenv", "FOO"],
-        "timeout": "1s"
       }
     },
     "prestart": ["check1"],
-    "poststart": ["check2", "check3"]
+    "poststart": ["check2"]
   }
 }`
 	r.Load(strings.NewReader(cfg))
@@ -91,10 +84,6 @@ func TestRun(t *testing.T) {
 	}
 
 	if err := validateCheck(poststart, "check2", expectedOutput); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := validateCheck(poststart, "check3", "bar\n"); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This causes exec.FullOutput to respect the PATH env var when looking for the executable by setting the env when the runner process starts. The subprocess will then inherit the correct environment from the runner process.