### PR TITLE
change the diagnostics bundle name

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -136,8 +136,7 @@ func (j *DiagnosticsJob) run(req bundleCreateRequest, dt *Dt) (createResponse, e
 	j.Errors = nil
 
 	t := time.Now()
-	bundleName := fmt.Sprintf("bundle-%d-%02d-%02dT%02d:%02d:%02d-%d.zip", t.Year(), t.Month(), t.Day(),
-		t.Hour(), t.Minute(), t.Second(), t.Nanosecond())
+	bundleName := fmt.Sprintf("bundle-%d-%02d-%02d-%d.zip", t.Year(), t.Month(), t.Day(), t.Unix())
 
 	j.LastBundlePath = filepath.Join(dt.Cfg.FlagDiagnosticsBundleDir, bundleName)
 	j.Status = "Diagnostics job started, archive will be available at: " + j.LastBundlePath


### PR DESCRIPTION
[COPS-1875](https://jira.mesosphere.com/browse/COPS-1875)

having colons in diagnostics bundle name is a bad idea, this is a problem for windows environment.
this PR changes the naming convention for diagnostics bundle to
`bundle-$year-$month-$day-$unixtimestamp.zip`