### PR TITLE
make error message verbose

### DIFF
--- a/api/pull.go
+++ b/api/pull.go
@@ -589,6 +589,14 @@ func pullHostStatus(host Node, respChan chan<- *httpResponse, dt *Dt, wg *sync.W
 	// use fake interface implementation for tests
 	timeout := time.Duration(dt.Cfg.FlagPullTimeoutSec) * time.Second
 	body, statusCode, err := dt.DtDCOSTools.Get(url, timeout)
+	if statusCode != http.StatusOK {
+		logrus.Errorf("Bad response code %d. URL %s", statusCode, url)
+		response.Status = statusCode
+		host.Health = 3
+		response.Node = host
+		respChan <- &response
+		return
+	}
 	if err != nil {
 		logrus.Errorf("Could not HTTP GET %s: %s", url, err)
 		response.Status = statusCode


### PR DESCRIPTION
if the dcos-diagnostics node responds with other then 200 status code,
we should make it clear in the logs.