### PR TITLE
Added support for running DCOS-Diagnostics in the agent role on a Windows agent node

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -951,7 +951,7 @@ func roleMatched(roles []string, DCOSTools DCOSHelper) (bool, error) {
 
 func (j *DiagnosticsJob) dispatchLogs(ctx context.Context, provider, entity string, cfg *config.Config, DCOSTools DCOSHelper) (r io.ReadCloser, err error) {
 	// make a buffered doneChan to communicate back to process.
-
+/*
 	if provider == "units" {
 		for _, endpoint := range j.logProviders.HTTPEndpoints {
 			if endpoint.FileName == entity {
@@ -969,7 +969,7 @@ func (j *DiagnosticsJob) dispatchLogs(ctx context.Context, provider, entity stri
 		}
 		return r, fmt.Errorf("%s not found", entity)
 	}
-
+*/
 	if provider == "files" {
 		logrus.Debugf("dispatching a file %s", entity)
 		for _, fileProvider := range j.logProviders.LocalFiles {

--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -126,7 +126,7 @@ func (j *DiagnosticsJob) run(req bundleCreateRequest, dt *Dt) (createResponse, e
 	_, err = os.Stat(dt.Cfg.FlagDiagnosticsBundleDir)
 	if os.IsNotExist(err) {
 		logrus.Infof("Directory: %s not found, attempting to create one", dt.Cfg.FlagDiagnosticsBundleDir)
-		if err := os.Mkdir(dt.Cfg.FlagDiagnosticsBundleDir, os.ModePerm); err != nil {
+		if err := os.MkdirAll(dt.Cfg.FlagDiagnosticsBundleDir, os.ModePerm); err != nil {
 			j.Status = "Could not create directory: " + dt.Cfg.FlagDiagnosticsBundleDir
 			return prepareCreateResponseWithErr(http.StatusServiceUnavailable, errors.New(j.Status))
 		}
@@ -272,6 +272,7 @@ func (j *DiagnosticsJob) runBackgroundJob(nodes []Node, cfg *config.Config, DCOS
 		updateSummaryReport("START collecting logs", node, "", summaryReport)
 		url := fmt.Sprintf("http://%s:%d%s/logs", node.IP, port, BaseRoute)
 		endpoints := make(map[string]string)
+		logrus.Errorf("url: %s", url)
 		body, statusCode, err := DCOSTools.Get(url, time.Duration(time.Second*3))
 		if err != nil {
 			errMsg := fmt.Sprintf("could not get a list of logs, url: %s, status code %d", url, statusCode)
@@ -281,6 +282,7 @@ func (j *DiagnosticsJob) runBackgroundJob(nodes []Node, cfg *config.Config, DCOS
 			j.JobProgressPercentage += percentPerNode
 			continue
 		}
+		logrus.Infof("json.Unmarshal: %v", body)
 		if err = json.Unmarshal(body, &endpoints); err != nil {
 			errMsg := "could not unmarshal a list of logs, url: " + url
 			j.Errors = append(j.Errors, errMsg)
@@ -771,7 +773,9 @@ type CommandProvider struct {
 }
 
 func loadExternalProviders(cfg *config.Config) (externalProviders LogProviders, err error) {
+	logrus.Infof("loadExternalProviders:")
 	// return if cfg file not found.
+	logrus.Infof("cfg.FlagDiagnosticsBundleEndpointsConfigFile: %s", cfg.FlagDiagnosticsBundleEndpointsConfigFile)
 	if _, err = os.Stat(cfg.FlagDiagnosticsBundleEndpointsConfigFile); err != nil {
 		if os.IsNotExist(err) {
 			logrus.Infof("%s not found", cfg.FlagDiagnosticsBundleEndpointsConfigFile)
@@ -786,10 +790,18 @@ func loadExternalProviders(cfg *config.Config) (externalProviders LogProviders, 
 	if err = json.Unmarshal(endpointsConfig, &externalProviders); err != nil {
 		return externalProviders, err
 	}
+
+	// for debugging purpose
+	logrus.Infof("HTTPEndpoints.count: %d", len(externalProviders.HTTPEndpoints))
+	for _, endpoint := range externalProviders.HTTPEndpoints {
+		logrus.Infof("Endpoint: Port %d , endpoint url: %s FileName:%s", endpoint.Port, endpoint.URI, endpoint.FileName)
+	}
+
 	return externalProviders, nil
 }
 
 func loadInternalProviders(cfg *config.Config, DCOSTools DCOSHelper) (internalConfigProviders LogProviders, err error) {
+	logrus.Infof("loadInternalProviders:")
 	units, err := DCOSTools.GetUnitNames()
 	if err != nil {
 		return internalConfigProviders, err
@@ -821,6 +833,12 @@ func loadInternalProviders(cfg *config.Config, DCOSTools DCOSHelper) (internalCo
 		URI:      BaseRoute,
 		FileName: "dcos-diagnostics-health.json",
 	})
+
+	logrus.Infof("role: %s  port: %d BaseRoute: %s", role, port, BaseRoute)
+	// for debugging purpose
+	for _, endpoint := range httpEndpoints {
+		logrus.Infof("Endpoint: Port %d , endpoint url: %s FileName:%s", endpoint.Port, endpoint.URI, endpoint.FileName)
+	}
 
 	return LogProviders{
 		HTTPEndpoints: httpEndpoints,
@@ -951,7 +969,7 @@ func roleMatched(roles []string, DCOSTools DCOSHelper) (bool, error) {
 
 func (j *DiagnosticsJob) dispatchLogs(ctx context.Context, provider, entity string, cfg *config.Config, DCOSTools DCOSHelper) (r io.ReadCloser, err error) {
 	// make a buffered doneChan to communicate back to process.
-/*
+
 	if provider == "units" {
 		for _, endpoint := range j.logProviders.HTTPEndpoints {
 			if endpoint.FileName == entity {
@@ -969,7 +987,7 @@ func (j *DiagnosticsJob) dispatchLogs(ctx context.Context, provider, entity stri
 		}
 		return r, fmt.Errorf("%s not found", entity)
 	}
-*/
+
 	if provider == "files" {
 		logrus.Debugf("dispatching a file %s", entity)
 		for _, fileProvider := range j.logProviders.LocalFiles {

--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -126,7 +126,7 @@ func (s *DiagnosticsTestSuit) TestFindRequestedNodes() {
 
 func (s *DiagnosticsTestSuit) TestGetStatus() {
 	status := s.dt.DtDiagnosticsJob.getStatus(s.dt.Cfg)
-	s.assert.Equal(status.DiagnosticBundlesBaseDir, "/tmp/snapshot-test")
+	s.assert.Equal(status.DiagnosticBundlesBaseDir, DiagnosticsBundleDir)
 }
 
 func (s *DiagnosticsTestSuit) TestGetAllStatus() {
@@ -372,7 +372,7 @@ func (s *DiagnosticsTestSuit) TestRunSnapshot() {
 		s.Assert()
 	}
 
-	bundle := "/tmp/snapshot-test/" + responseJSON.Extra.LastBundleFile
+	bundle := DiagnosticsBundleDir + "/" + responseJSON.Extra.LastBundleFile
 	defer func() {
 		err := os.Remove(bundle)
 		s.assert.NoError(err)
@@ -386,7 +386,7 @@ func (s *DiagnosticsTestSuit) TestRunSnapshot() {
 	s.assert.Equal(responseJSON.Status, "Job has been successfully started")
 	s.assert.NotEmpty(responseJSON.Extra.LastBundleFile)
 	time.Sleep(2 * time.Second)
-	snapshotFiles, err := ioutil.ReadDir("/tmp/snapshot-test")
+	snapshotFiles, err := ioutil.ReadDir(DiagnosticsBundleDir)
 	s.assert.NoError(err)
 	s.assert.True(len(snapshotFiles) > 0)
 

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -7,22 +7,31 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/dcos/dcos-diagnostics/config"
 	"github.com/gorilla/mux"
 	assertPackage "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
+var DiagnosticsBundleDir = "/tmp/snapshot-test"
 var testCfg *config.Config
 
 func init() {
+	if runtime.GOOS == "windows" {
+		DiagnosticsBundleDir = os.Getenv("SYSTEMDRIVE") + "\\tmp\\snapshot-test"
+	}
+	logrus.Infof("DiagnosticsBundleDir=%v", DiagnosticsBundleDir)
+
 	testCfg = &config.Config{
 		FlagRole:                 "master",
-		FlagDiagnosticsBundleDir: "/tmp/snapshot-test",
+		FlagDiagnosticsBundleDir: DiagnosticsBundleDir,
 		FlagPort:                 1050,
 		FlagMasterPort:           1050,
 	}
@@ -87,11 +96,11 @@ func (st *fakeDCOSTools) GetUnitProperties(pname string) (map[string]interface{}
 	return result, nil
 }
 
-func (st *fakeDCOSTools) InitializeDBUSConnection() error {
+func (st *fakeDCOSTools) InitializeUnitControllerConnection() error {
 	return nil
 }
 
-func (st *fakeDCOSTools) CloseDBUSConnection() error {
+func (st *fakeDCOSTools) CloseUnitControllerConnection() error {
 	return nil
 }
 
@@ -99,10 +108,10 @@ func (st *fakeDCOSTools) GetUnitNames() (units []string, err error) {
 	units = []string{"dcos-setup.service", "dcos-link-env.service", "dcos-download.service", "unit_a", "unit_b", "unit_c", "unit_to_fail"}
 	return units, err
 }
-/*
+
 func (st *fakeDCOSTools) GetJournalOutput(unit string) (string, error) {
 	return "journal output", nil
-}*/
+}
 
 func (st *fakeDCOSTools) GetMesosNodeID() (string, error) {
 	return "node-id-123", nil

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -99,10 +99,10 @@ func (st *fakeDCOSTools) GetUnitNames() (units []string, err error) {
 	units = []string{"dcos-setup.service", "dcos-link-env.service", "dcos-download.service", "unit_a", "unit_b", "unit_c", "unit_to_fail"}
 	return units, err
 }
-
+/*
 func (st *fakeDCOSTools) GetJournalOutput(unit string) (string, error) {
 	return "journal output", nil
-}
+}*/
 
 func (st *fakeDCOSTools) GetMesosNodeID() (string, error) {
 	return "node-id-123", nil

--- a/api/health_linux.go
+++ b/api/health_linux.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"os"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/dcos/dcos-diagnostics/config"
+)
+
+// SystemdUnits used to make GetUnitsProperties thread safe.
+type SystemdUnits struct {
+	sync.Mutex
+}
+
+// GetUnits returns a list of found unit properties.
+func (s *SystemdUnits) GetUnits(tools DCOSHelper) (allUnits []HealthResponseValues, err error) {
+	if err = tools.InitializeUnitControllerConnection(); err != nil {
+		return nil, err
+	}
+	defer tools.CloseUnitControllerConnection()
+
+	// detect DC/OS systemd units
+	foundUnits, err := tools.GetUnitNames()
+	if err != nil {
+		return nil, err
+	}
+
+	// DCOS-5862 blacklist systemd units
+	excludeUnits := []string{"dcos-setup.service", "dcos-link-env.service", "dcos-download.service"}
+	for _, unit := range foundUnits {
+		if isInList(unit, excludeUnits) {
+			logrus.Debugf("Skipping blacklisted systemd Unit %s", unit)
+			continue
+		}
+		currentProperty, err := tools.GetUnitProperties(unit)
+		if err != nil {
+			logrus.Errorf("Could not get properties for Unit: %s", unit)
+			continue
+		}
+		normalizedProperty, err := normalizeProperty(currentProperty, tools)
+		if err != nil {
+			logrus.Errorf("Could not normalize property for Unit %s: %s", unit, err)
+			continue
+		}
+		allUnits = append(allUnits, normalizedProperty)
+	}
+	return allUnits, nil
+}
+
+// GetUnitsProperties return a structured units health response of UnitsHealthResponseJsonStruct type.
+func (s *SystemdUnits) GetUnitsProperties(cfg *config.Config, tools DCOSHelper) (healthReport UnitsHealthResponseJSONStruct, err error) {
+	s.Lock()
+	defer s.Unlock()
+
+	healthReport.TdtVersion = config.Version
+	healthReport.Hostname, err = tools.GetHostname()
+	if err != nil {
+		logrus.Errorf("Could not get a hostname: %s", err)
+	}
+
+	// update the rest of healthReport fields
+	healthReport.Array, err = s.GetUnits(tools)
+	if err != nil {
+		logrus.Errorf("Unable to get a list of systemd units: %s", err)
+	}
+
+	healthReport.IPAddress, err = tools.DetectIP()
+	if err != nil {
+		logrus.Errorf("Could not detect IP: %s", err)
+	}
+
+	healthReport.DcosVersion = os.Getenv("DCOS_VERSION")
+	healthReport.Role, err = tools.GetNodeRole()
+	if err != nil {
+		logrus.Errorf("Could not get node role: %s", err)
+	}
+
+	healthReport.MesosID, err = tools.GetMesosNodeID()
+	if err != nil {
+		logrus.Errorf("Could not get mesos node id: %s", err)
+	}
+
+	return healthReport, nil
+}

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/coreos/go-systemd/dbus"
 	"github.com/dcos/dcos-go/dcos/nodeutil"
-	"github.com/dcos/dcos-log/dcos-log/journal/reader"
+	//"github.com/dcos/dcos-log/dcos-log/journal/reader"
 )
 
 const (
@@ -142,7 +142,7 @@ func (st *DCOSTools) GetUnitNames() (units []string, err error) {
 	logrus.Debugf("List of units: %s", units)
 	return units, nil
 }
-
+/*
 // GetJournalOutput returns last 50 lines of journald command output for a specific systemd Unit.
 func (st *DCOSTools) GetJournalOutput(unit string) (string, error) {
 	matches := defaultSystemdMatches(unit)
@@ -160,6 +160,7 @@ func (st *DCOSTools) GetJournalOutput(unit string) (string, error) {
 
 	return string(entries), nil
 }
+*/
 
 func useTLSScheme(url string, use bool) (string, error) {
 	if use {
@@ -345,7 +346,7 @@ func normalizeProperty(unitProps map[string]interface{}, tools DCOSHelper) (Heal
 	if err != nil {
 		return HealthResponseValues{}, err
 	}
-
+/*
 	if unitHealth > 0 {
 		journalOutput, err := tools.GetJournalOutput(propsResponse.ID)
 		if err == nil {
@@ -355,7 +356,7 @@ func normalizeProperty(unitProps map[string]interface{}, tools DCOSHelper) (Heal
 			logrus.Errorf("Could not read journalctl: %s", err)
 		}
 	}
-
+*/
 	s := strings.Split(propsResponse.Description, ": ")
 	if len(s) != 2 {
 		description = strings.Join(s, " ")
@@ -382,7 +383,7 @@ func readFile(fileLocation string) (r io.ReadCloser, err error) {
 	}
 	return file, nil
 }
-
+/*
 func readJournalOutputSince(unit, sinceString string) (io.ReadCloser, error) {
 	matches := defaultSystemdMatches(unit)
 	duration, err := time.ParseDuration(sinceString)
@@ -398,7 +399,8 @@ func readJournalOutputSince(unit, sinceString string) (io.ReadCloser, error) {
 
 	return j, nil
 }
-
+*/
+/*
 // returns default reader.JournalEntryMatch for a given systemd unit.
 func defaultSystemdMatches(unit string) []reader.JournalEntryMatch {
 	return []reader.JournalEntryMatch{
@@ -412,3 +414,4 @@ func defaultSystemdMatches(unit string) []reader.JournalEntryMatch {
 		},
 	}
 }
+*/

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -1,22 +1,15 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	netUrl "net/url"
 	"os"
-	"strings"
-	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/coreos/go-systemd/dbus"
-	"github.com/dcos/dcos-go/dcos/nodeutil"
-	//"github.com/dcos/dcos-log/dcos-log/journal/reader"
 )
 
 const (
@@ -26,6 +19,7 @@ const (
 	unitProperty        = "UNIT"
 )
 
+/*
 // DCOSTools is implementation of DCOSHelper interface.
 type DCOSTools struct {
 	sync.Mutex
@@ -41,6 +35,7 @@ type DCOSTools struct {
 	ip       string
 	mesosID  string
 }
+*/
 
 // GetHostname return a localhost hostname.
 func (st *DCOSTools) GetHostname() (string, error) {
@@ -73,94 +68,6 @@ func (st *DCOSTools) GetNodeRole() (string, error) {
 	}
 	return st.Role, nil
 }
-
-// InitializeDBUSConnection opens a dbus connection. The connection is available via st.dcon
-func (st *DCOSTools) InitializeDBUSConnection() (err error) {
-	// we need to lock the dbus connection for each request
-	st.Lock()
-	if st.dcon == nil {
-		st.dcon, err = dbus.New()
-		if err != nil {
-			st.Unlock()
-			return err
-		}
-		return nil
-	}
-	st.Unlock()
-	return errors.New("dbus connection is already opened")
-}
-
-// CloseDBUSConnection closes a dbus connection.
-func (st *DCOSTools) CloseDBUSConnection() error {
-	// unlock the dbus connection no matter what
-	defer st.Unlock()
-	if st.dcon != nil {
-		st.dcon.Close()
-		// since dbus api does not provide a way to check that the connection is closed, we'd nil it.
-		st.dcon = nil
-		return nil
-	}
-	return errors.New("dbus connection is closed")
-}
-
-// GetUnitProperties return a map of systemd Unit properties received from dbus.
-func (st *DCOSTools) GetUnitProperties(pname string) (result map[string]interface{}, err error) {
-	result = make(map[string]interface{})
-	result, err = st.dcon.GetUnitProperties(pname)
-	if err != nil {
-		return result, err
-	}
-
-	// Get Service property
-	propSlice := strings.Split(pname, ".")
-	if len(propSlice) != 2 {
-		return result, fmt.Errorf("Unit name must be in the following format: unitName.Type, got: %s", pname)
-	}
-
-	// let's get service specific properties
-	// https://www.freedesktop.org/wiki/Software/systemd/dbus/
-	if propSlice[1] == "service" {
-		// "ExecMainStatus" will tell us main process exit code
-		p, err := st.dcon.GetServiceProperty(pname, "ExecMainStatus")
-		if err != nil {
-			return result, err
-		}
-		result[p.Name] = p.Value.Value()
-	}
-	return result, nil
-}
-
-// GetUnitNames read a directory /etc/systemd/system/dcos.target.wants and return a list of found systemd units.
-func (st *DCOSTools) GetUnitNames() (units []string, err error) {
-	files, err := ioutil.ReadDir("/etc/systemd/system/dcos.target.wants")
-	if err != nil {
-		return units, err
-	}
-	for _, f := range files {
-		units = append(units, f.Name())
-	}
-	logrus.Debugf("List of units: %s", units)
-	return units, nil
-}
-/*
-// GetJournalOutput returns last 50 lines of journald command output for a specific systemd Unit.
-func (st *DCOSTools) GetJournalOutput(unit string) (string, error) {
-	matches := defaultSystemdMatches(unit)
-	format := reader.NewEntryFormatter("text/plain", false)
-	j, err := reader.NewReader(format, reader.OptionMatchOR(matches), reader.OptionSkipPrev(50))
-	if err != nil {
-		return "", err
-	}
-	defer j.Journal.Close()
-
-	entries, err := ioutil.ReadAll(j)
-	if err != nil {
-		return "", err
-	}
-
-	return string(entries), nil
-}
-*/
 
 func useTLSScheme(url string, use bool) (string, error) {
 	if use {
@@ -286,95 +193,6 @@ func NewHTTPClient(timeout time.Duration, transport http.RoundTripper) *http.Cli
 	return client
 }
 
-// CheckUnitHealth tells if the Unit is healthy
-func (u *UnitPropertiesResponse) CheckUnitHealth() (int, string, error) {
-	if u.LoadState == "" || u.ActiveState == "" || u.SubState == "" {
-		return 1, "", fmt.Errorf("LoadState: %s, ActiveState: %s and SubState: %s must be set",
-			u.LoadState, u.ActiveState, u.SubState)
-	}
-
-	if u.LoadState != "loaded" {
-		return 1, fmt.Sprintf("%s is not loaded. Please check `systemctl show all` to check current Unit status.", u.ID), nil
-	}
-
-	okActiveStates := []string{"active", "inactive", "activating"}
-	if !isInList(u.ActiveState, okActiveStates) {
-		return 1, fmt.Sprintf(
-			"%s state is not one of the possible states %s. Current state is [ %s ]. "+
-				"Please check `systemctl show all %s` to check current Unit state. ", u.ID, okActiveStates, u.ActiveState, u.ID), nil
-	}
-	logrus.Debugf("%s| ExecMainStatus = %d", u.ID, u.ExecMainStatus)
-	if u.ExecMainStatus != 0 {
-		return 1, fmt.Sprintf("ExecMainStatus return failed status for %s", u.ID), nil
-	}
-
-	// https://www.freedesktop.org/wiki/Software/systemd/dbus/
-	// if a Unit is in `activating` state and `auto-restart` sub-state it means Unit is trying to start and fails.
-	if u.ActiveState == "activating" && u.SubState == "auto-restart" {
-		// If ActiveEnterTimestampMonotonic is 0, it means that Unit has never been able to switch to active state.
-		// Most likely a ExecStartPre fails before the Unit can execute ExecStart.
-		if u.ActiveEnterTimestampMonotonic == 0 {
-			return 1, fmt.Sprintf("Unit %s has never entered `active` state", u.ID), nil
-		}
-
-		// If InactiveEnterTimestampMonotonic > ActiveEnterTimestampMonotonic that means that a Unit was active
-		// some time ago, but then something happened and it cannot restart.
-		if u.InactiveEnterTimestampMonotonic > u.ActiveEnterTimestampMonotonic {
-			return 1, fmt.Sprintf("Unit %s is flapping. Please check `systemctl status %s` to check current Unit state.", u.ID, u.ID), nil
-		}
-	}
-
-	return 0, "", nil
-}
-
-func normalizeProperty(unitProps map[string]interface{}, tools DCOSHelper) (HealthResponseValues, error) {
-	var (
-		description, prettyName string
-		propsResponse           UnitPropertiesResponse
-	)
-
-	marshaledPropsResponse, err := json.Marshal(unitProps)
-	if err != nil {
-		return HealthResponseValues{}, err
-	}
-
-	if err = json.Unmarshal(marshaledPropsResponse, &propsResponse); err != nil {
-		return HealthResponseValues{}, err
-	}
-
-	unitHealth, unitOutput, err := propsResponse.CheckUnitHealth()
-	if err != nil {
-		return HealthResponseValues{}, err
-	}
-/*
-	if unitHealth > 0 {
-		journalOutput, err := tools.GetJournalOutput(propsResponse.ID)
-		if err == nil {
-			unitOutput += "\n"
-			unitOutput += journalOutput
-		} else {
-			logrus.Errorf("Could not read journalctl: %s", err)
-		}
-	}
-*/
-	s := strings.Split(propsResponse.Description, ": ")
-	if len(s) != 2 {
-		description = strings.Join(s, " ")
-
-	} else {
-		prettyName, description = s[0], s[1]
-	}
-
-	return HealthResponseValues{
-		UnitID:     propsResponse.ID,
-		UnitHealth: unitHealth,
-		UnitOutput: unitOutput,
-		UnitTitle:  description,
-		Help:       "",
-		PrettyName: prettyName,
-	}, nil
-}
-
 // open a file for reading, a caller if responsible to close a file descriptor.
 func readFile(fileLocation string) (r io.ReadCloser, err error) {
 	file, err := os.Open(fileLocation)
@@ -383,35 +201,3 @@ func readFile(fileLocation string) (r io.ReadCloser, err error) {
 	}
 	return file, nil
 }
-/*
-func readJournalOutputSince(unit, sinceString string) (io.ReadCloser, error) {
-	matches := defaultSystemdMatches(unit)
-	duration, err := time.ParseDuration(sinceString)
-	if err != nil {
-		logrus.Errorf("Error parsing %s. Defaulting to 24 hours", sinceString)
-		duration = time.Hour * 24
-	}
-	format := reader.NewEntryFormatter("text/plain", false)
-	j, err := reader.NewReader(format, reader.OptionMatchOR(matches), reader.OptionSince(duration))
-	if err != nil {
-		return nil, err
-	}
-
-	return j, nil
-}
-*/
-/*
-// returns default reader.JournalEntryMatch for a given systemd unit.
-func defaultSystemdMatches(unit string) []reader.JournalEntryMatch {
-	return []reader.JournalEntryMatch{
-		{
-			Field: systemdUnitProperty,
-			Value: unit,
-		},
-		{
-			Field: unitProperty,
-			Value: unit,
-		},
-	}
-}
-*/

--- a/api/helpers_linux.go
+++ b/api/helpers_linux.go
@@ -1,0 +1,240 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/coreos/go-systemd/dbus"
+	"github.com/dcos/dcos-go/dcos/nodeutil"
+	"github.com/dcos/dcos-log/dcos-log/journal/reader"
+)
+
+// DCOSTools is implementation of DCOSHelper interface.
+type DCOSTools struct {
+	sync.Mutex
+
+	ExhibitorURL string
+	Role         string
+	ForceTLS     bool
+	NodeInfo     nodeutil.NodeInfo
+	Transport    http.RoundTripper
+
+	dcon     *dbus.Conn
+	hostname string
+	ip       string
+	mesosID  string
+}
+
+// InitializeUnitControllerConnection opens a dbus connection. The connection is available via st.dcon
+func (st *DCOSTools) InitializeUnitControllerConnection() (err error) {
+	// we need to lock the dbus connection for each request
+	st.Lock()
+	if st.dcon == nil {
+		st.dcon, err = dbus.New()
+		if err != nil {
+			st.Unlock()
+			return err
+		}
+		return nil
+	}
+	st.Unlock()
+	return errors.New("dbus connection is already opened")
+}
+
+// CloseUnitControllerConnection closes a dbus connection.
+func (st *DCOSTools) CloseUnitControllerConnection() error {
+	// unlock the dbus connection no matter what
+	defer st.Unlock()
+	if st.dcon != nil {
+		st.dcon.Close()
+		// since dbus api does not provide a way to check that the connection is closed, we'd nil it.
+		st.dcon = nil
+		return nil
+	}
+	return errors.New("dbus connection is closed")
+}
+
+// GetUnitProperties return a map of systemd Unit properties received from dbus.
+func (st *DCOSTools) GetUnitProperties(pname string) (result map[string]interface{}, err error) {
+	result = make(map[string]interface{})
+	result, err = st.dcon.GetUnitProperties(pname)
+	if err != nil {
+		return result, err
+	}
+
+	// Get Service property
+	propSlice := strings.Split(pname, ".")
+	if len(propSlice) != 2 {
+		return result, fmt.Errorf("Unit name must be in the following format: unitName.Type, got: %s", pname)
+	}
+
+	// let's get service specific properties
+	// https://www.freedesktop.org/wiki/Software/systemd/dbus/
+	if propSlice[1] == "service" {
+		// "ExecMainStatus" will tell us main process exit code
+		p, err := st.dcon.GetServiceProperty(pname, "ExecMainStatus")
+		if err != nil {
+			return result, err
+		}
+		result[p.Name] = p.Value.Value()
+	}
+	return result, nil
+}
+
+// GetUnitNames read a directory /etc/systemd/system/dcos.target.wants and return a list of found systemd units.
+func (st *DCOSTools) GetUnitNames() (units []string, err error) {
+	files, err := ioutil.ReadDir("/etc/systemd/system/dcos.target.wants")
+	if err != nil {
+		return units, err
+	}
+	for _, f := range files {
+		units = append(units, f.Name())
+	}
+	logrus.Debugf("List of units: %s", units)
+	return units, nil
+}
+
+// GetJournalOutput returns last 50 lines of journald command output for a specific systemd Unit.
+func (st *DCOSTools) GetJournalOutput(unit string) (string, error) {
+	matches := defaultSystemdMatches(unit)
+	format := reader.NewEntryFormatter("text/plain", false)
+	j, err := reader.NewReader(format, reader.OptionMatchOR(matches), reader.OptionSkipPrev(50))
+	if err != nil {
+		return "", err
+	}
+	defer j.Journal.Close()
+
+	entries, err := ioutil.ReadAll(j)
+	if err != nil {
+		return "", err
+	}
+
+	return string(entries), nil
+}
+
+func normalizeProperty(unitProps map[string]interface{}, tools DCOSHelper) (HealthResponseValues, error) {
+	var (
+		description, prettyName string
+		propsResponse           UnitPropertiesResponse
+	)
+
+	marshaledPropsResponse, err := json.Marshal(unitProps)
+	if err != nil {
+		return HealthResponseValues{}, err
+	}
+
+	if err = json.Unmarshal(marshaledPropsResponse, &propsResponse); err != nil {
+		return HealthResponseValues{}, err
+	}
+
+	unitHealth, unitOutput, err := propsResponse.CheckUnitHealth()
+	if err != nil {
+		return HealthResponseValues{}, err
+	}
+
+	if unitHealth > 0 {
+		journalOutput, err := tools.GetJournalOutput(propsResponse.ID)
+		if err == nil {
+			unitOutput += "\n"
+			unitOutput += journalOutput
+		} else {
+			logrus.Errorf("Could not read journalctl: %s", err)
+		}
+	}
+
+	s := strings.Split(propsResponse.Description, ": ")
+	if len(s) != 2 {
+		description = strings.Join(s, " ")
+
+	} else {
+		prettyName, description = s[0], s[1]
+	}
+
+	return HealthResponseValues{
+		UnitID:     propsResponse.ID,
+		UnitHealth: unitHealth,
+		UnitOutput: unitOutput,
+		UnitTitle:  description,
+		Help:       "",
+		PrettyName: prettyName,
+	}, nil
+}
+
+// CheckUnitHealth tells if the Unit is healthy
+func (u *UnitPropertiesResponse) CheckUnitHealth() (int, string, error) {
+	if u.LoadState == "" || u.ActiveState == "" || u.SubState == "" {
+		return 1, "", fmt.Errorf("LoadState: %s, ActiveState: %s and SubState: %s must be set",
+			u.LoadState, u.ActiveState, u.SubState)
+	}
+
+	if u.LoadState != "loaded" {
+		return 1, fmt.Sprintf("%s is not loaded. Please check `systemctl show all` to check current Unit status.", u.ID), nil
+	}
+
+	okActiveStates := []string{"active", "inactive", "activating"}
+	if !isInList(u.ActiveState, okActiveStates) {
+		return 1, fmt.Sprintf(
+			"%s state is not one of the possible states %s. Current state is [ %s ]. "+
+				"Please check `systemctl show all %s` to check current Unit state. ", u.ID, okActiveStates, u.ActiveState, u.ID), nil
+	}
+	logrus.Debugf("%s| ExecMainStatus = %d", u.ID, u.ExecMainStatus)
+	if u.ExecMainStatus != 0 {
+		return 1, fmt.Sprintf("ExecMainStatus return failed status for %s", u.ID), nil
+	}
+
+	// https://www.freedesktop.org/wiki/Software/systemd/dbus/
+	// if a Unit is in `activating` state and `auto-restart` sub-state it means Unit is trying to start and fails.
+	if u.ActiveState == "activating" && u.SubState == "auto-restart" {
+		// If ActiveEnterTimestampMonotonic is 0, it means that Unit has never been able to switch to active state.
+		// Most likely a ExecStartPre fails before the Unit can execute ExecStart.
+		if u.ActiveEnterTimestampMonotonic == 0 {
+			return 1, fmt.Sprintf("Unit %s has never entered `active` state", u.ID), nil
+		}
+
+		// If InactiveEnterTimestampMonotonic > ActiveEnterTimestampMonotonic that means that a Unit was active
+		// some time ago, but then something happened and it cannot restart.
+		if u.InactiveEnterTimestampMonotonic > u.ActiveEnterTimestampMonotonic {
+			return 1, fmt.Sprintf("Unit %s is flapping. Please check `systemctl status %s` to check current Unit state.", u.ID, u.ID), nil
+		}
+	}
+
+	return 0, "", nil
+}
+
+func readJournalOutputSince(unit, sinceString string) (io.ReadCloser, error) {
+	matches := defaultSystemdMatches(unit)
+	duration, err := time.ParseDuration(sinceString)
+	if err != nil {
+		logrus.Errorf("Error parsing %s. Defaulting to 24 hours", sinceString)
+		duration = time.Hour * 24
+	}
+	format := reader.NewEntryFormatter("text/plain", false)
+	j, err := reader.NewReader(format, reader.OptionMatchOR(matches), reader.OptionSince(duration))
+	if err != nil {
+		return nil, err
+	}
+
+	return j, nil
+}
+
+// returns default reader.JournalEntryMatch for a given systemd unit.
+func defaultSystemdMatches(unit string) []reader.JournalEntryMatch {
+	return []reader.JournalEntryMatch{
+		{
+			Field: systemdUnitProperty,
+			Value: unit,
+		},
+		{
+			Field: unitProperty,
+			Value: unit,
+		},
+	}
+}

--- a/api/helpers_windows.go
+++ b/api/helpers_windows.go
@@ -1,0 +1,210 @@
+package api
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/dcos/dcos-go/dcos/nodeutil"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+const (
+	// WindowsServiceListFile has the expected service list, generated
+	// during cluster deployment
+	WindowsServiceListFile = "servicelist.txt"
+)
+
+// DCOSTools is implementation of DCOSHelper interface.
+type DCOSTools struct {
+	sync.Mutex
+
+	ExhibitorURL string
+	Role         string
+	ForceTLS     bool
+	NodeInfo     nodeutil.NodeInfo
+	Transport    http.RoundTripper
+
+	//dcon     *dbus.Conn
+	svcManager *mgr.Mgr
+
+	hostname string
+	ip       string
+	mesosID  string
+}
+
+// InitializeUnitControllerConnection opens a connection.
+func (st *DCOSTools) InitializeUnitControllerConnection() (err error) {
+	st.Lock()
+	if st.svcManager == nil {
+		st.svcManager, err = mgr.Connect()
+		if err != nil {
+			st.Unlock()
+			return err
+		}
+		return nil
+	}
+	st.Unlock()
+	return errors.New("connection is already opened")
+}
+
+// CloseUnitControllerConnection closes a dbus connection.
+func (st *DCOSTools) CloseUnitControllerConnection() error {
+	// unlock the connection no matter what
+	defer st.Unlock()
+	if st.svcManager != nil {
+		err := st.svcManager.Disconnect()
+		if err != nil {
+			return err
+		}
+		st.svcManager = nil
+		return nil
+	}
+	return errors.New("connection is closed")
+}
+
+// GetUnitProperties return a map of Windows service properties
+func (st *DCOSTools) GetUnitProperties(pname string) (map[string]interface{}, error) {
+	var serviceHandle *mgr.Service
+
+	if st.svcManager == nil {
+		return nil, errors.New("connection was not opened")
+	}
+
+	// search for the target service
+	serviceList, err := st.svcManager.ListServices()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, service := range serviceList {
+		if strings.Compare(pname, service) == 0 {
+			serviceHandle, err = st.svcManager.OpenService(pname)
+			if err != nil {
+				return nil, err
+			}
+			break
+		}
+	}
+
+	if serviceHandle == nil {
+		return nil, errors.New("service not found")
+	}
+	defer serviceHandle.Close()
+
+	// get service config
+	var config mgr.Config
+	config, err = serviceHandle.Config()
+	if err != nil {
+		return nil, err
+	}
+	logrus.Debugf("config.DisplayName: [%s]", config.DisplayName)
+	logrus.Debugf("config.Description: [%d]", config.Description)
+	logrus.Debugf("config.BinaryPathName: [%s]", config.BinaryPathName)
+
+	status, err := serviceHandle.Query()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]interface{})
+	result["Id"] = pname
+	result["ActiveState"] = string(status.State)
+	result["LoadState"] = string(status.State)
+	result["SubState"] = string(status.State)
+	result["Description"] = config.Description
+
+	logrus.Debugf("GetUnitProperties for service: result= %v", pname, result)
+	return result, nil
+}
+
+// GetUnitNames reads from WindowsServiceListFile for a list of expected Windows services on the agent node
+// In Windows, "units" are equivalent to Windows services
+func (st *DCOSTools) GetUnitNames() (units []string, err error) {
+	// read all the Windows services from WindowsServiceListFile file
+	ex, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	exPath := filepath.Dir(ex)
+	servicelistpath := exPath + "\\" + WindowsServiceListFile
+
+	file, err := os.Open(servicelistpath)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		units = append(units, scanner.Text())
+	}
+	logrus.Infof("GetUnitNames: %s has %v", servicelistpath, units)
+	return units, nil
+}
+
+// GetJournalOutput returns nil, as it's not supported on a Windwos agent node
+func (st *DCOSTools) GetJournalOutput(unit string) (string, error) {
+	return "", nil
+}
+
+func normalizeProperty(unitProps map[string]interface{}, tools DCOSHelper) (HealthResponseValues, error) {
+	var (
+		description, prettyName string
+		propsResponse           UnitPropertiesResponse
+	)
+
+	marshaledPropsResponse, err := json.Marshal(unitProps)
+	if err != nil {
+		return HealthResponseValues{}, err
+	}
+
+	if err = json.Unmarshal(marshaledPropsResponse, &propsResponse); err != nil {
+		return HealthResponseValues{}, err
+	}
+
+	unitHealth, unitOutput, err := propsResponse.CheckUnitHealth()
+	if err != nil {
+		return HealthResponseValues{}, err
+	}
+
+	s := strings.Split(propsResponse.Description, ": ")
+	if len(s) != 2 {
+		description = strings.Join(s, " ")
+
+	} else {
+		prettyName, description = s[0], s[1]
+	}
+
+	return HealthResponseValues{
+		UnitID:     propsResponse.ID,
+		UnitHealth: unitHealth,
+		UnitOutput: unitOutput,
+		UnitTitle:  description,
+		Help:       "",
+		PrettyName: prettyName,
+	}, nil
+}
+
+// CheckUnitHealth tells if the Unit is healthy
+func (u *UnitPropertiesResponse) CheckUnitHealth() (int, string, error) {
+
+	if u.ActiveState != string(svc.Running) {
+		logrus.Infof("The ActiveState is %s, not in running state(4)", u.ActiveState)
+		return 1, fmt.Sprintf("The ActiveState is %s, not in running state(4)", u.ActiveState), nil
+	}
+	return 0, "", nil
+}
+
+func readJournalOutputSince(unit, sinceString string) (io.ReadCloser, error) {
+	return nil, nil
+}

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -40,7 +40,7 @@ type DCOSHelper interface {
 	GetUnitNames() ([]string, error)
 
 	// Get journal output
-	GetJournalOutput(string) (string, error)
+	//GetJournalOutput(string) (string, error)
 
 	// Get mesos node id, first argument is a function to determine a role.
 	GetMesosNodeID() (string, error)

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -17,10 +17,10 @@ type HTTPRequester interface {
 // DCOSHelper DC/OS specific tools interface.
 type DCOSHelper interface {
 	// open dbus connection
-	InitializeDBUSConnection() error
+	InitializeUnitControllerConnection() error
 
 	// close dbus connection
-	CloseDBUSConnection() error
+	CloseUnitControllerConnection() error
 
 	// function to get Connection.GetUnitProperties(pname)
 	// returns a maps of properties https://github.com/coreos/go-systemd/blob/master/dbus/methods.go#L176
@@ -40,7 +40,7 @@ type DCOSHelper interface {
 	GetUnitNames() ([]string, error)
 
 	// Get journal output
-	//GetJournalOutput(string) (string, error)
+	GetJournalOutput(string) (string, error)
 
 	// Get mesos node id, first argument is a function to determine a role.
 	GetMesosNodeID() (string, error)

--- a/api/router.go
+++ b/api/router.go
@@ -318,6 +318,10 @@ func getRoutes(debug bool) []routeHandler {
 		}...)
 	}
 
+	for i, route := range routes {
+		logrus.Debug(i, ": route.url=", route.url)
+	}
+
 	return routes
 }
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/dcos/dcos-diagnostics/runner"
@@ -29,10 +30,9 @@ const (
 	checkTypeCluster       = "cluster"
 	checkTypeNodePreStart  = "node-prestart"
 	checkTypeNodePostStart = "node-poststart"
-
-	defaultRunnerConfig = "/opt/mesosphere/etc/dcos-diagnostics-runner-config.json"
 )
 
+var defaultRunnerConfig = "/opt/mesosphere/etc/dcos-diagnostics-runner-config.json"
 var (
 	list          bool
 	checksCfgFile string
@@ -96,6 +96,13 @@ var checkCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(checkCmd)
+
+	if runtime.GOOS == "windows" {
+		defaultRunnerConfig = os.Getenv("SYSTEMDRIVE") + 
+		                       "\\DCOS\\diagnostics\\config\\dcos-diagnostics-runner-config.json"
+	}
+	logrus.Infof("defaultRunnerConfig=%v", defaultRunnerConfig)
+
 	checkCmd.PersistentFlags().BoolVar(&list, "list", false, "List runner")
 	checkCmd.PersistentFlags().StringVar(&checksCfgFile, "check-config", defaultRunnerConfig,
 		"Path to dcos-check config file")

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -19,10 +19,11 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"runtime"
 	"strconv"
 
 	"github.com/Sirupsen/logrus"
-//	"github.com/coreos/go-systemd/activation"
 	"github.com/dcos/dcos-diagnostics/api"
 	"github.com/dcos/dcos-go/dcos"
 	"github.com/dcos/dcos-go/dcos/http/transport"
@@ -129,6 +130,13 @@ func startDiagnosticsDaemon() {
 	if defaultConfig.FlagForceTLS {
 		options = append(options, nodeutil.OptionMesosStateURL(defaultStateURL.String()))
 	}
+	if runtime.GOOS == "windows" {
+		detectIPScriptPath := os.Getenv("SYSTEMDRIVE") + "\\DCOS\\diagnostics\\detect_ip.ps1"
+		options = append(options, nodeutil.OptionDetectIP(detectIPScriptPath))
+	}
+
+	logrus.Infof("defaultConfig.FlagRole is %s", defaultConfig.FlagRole)
+
 	nodeInfo, err := nodeutil.NewNodeInfo(client, defaultConfig.FlagRole, options...)
 	if err != nil {
 		logrus.Fatalf("Could not initialize nodeInfo: %s", err)

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/coreos/go-systemd/activation"
+//	"github.com/coreos/go-systemd/activation"
 	"github.com/dcos/dcos-diagnostics/api"
 	"github.com/dcos/dcos-go/dcos"
 	"github.com/dcos/dcos-go/dcos/http/transport"
@@ -177,7 +177,8 @@ func startDiagnosticsDaemon() {
 	}
 
 	// try using systemd socket
-	listeners, err := activation.Listeners(true)
+	// listeners, err := activation.Listeners(true)
+	listeners, err := getListener(true)
 	if err != nil {
 		logrus.Fatalf("Unable to initialize listener: %s", err)
 	}

--- a/cmd/listener_linux.go
+++ b/cmd/listener_linux.go
@@ -1,0 +1,30 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net"
+	"os"
+
+	"github.com/coreos/go-systemd/activation"
+)
+
+func getListener(unsetEnv bool) ([]net.Listener, error) {
+	return activation.Listeners(true)
+}
+
+func getFiles(unsetEnv bool) []*os.File {
+	return activation.Files(unsetEnv)
+}

--- a/cmd/listener_windows.go
+++ b/cmd/listener_windows.go
@@ -1,0 +1,28 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net"
+	"os"
+)
+
+func getListener(unsetEnv bool) ([]net.Listener, error) {
+	return nil, nil
+}
+
+func getFiles(unsetEnv bool) []*os.File {
+	return nil
+}

--- a/runner/check_test.go
+++ b/runner/check_test.go
@@ -2,14 +2,19 @@ package runner
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"testing"
 )
 
 func TestCombinedOutput(t *testing.T) {
 	ch1 := &Check{
-		Cmd:   []string{"./fixture/combined.sh"},
+		Cmd:   []string{CombinedShScript},
 		Roles: []string{"master"},
+	}
+
+	if runtime.GOOS == "windows" {
+		ch1.Cmd = []string{CombinedPowershellScript}
 	}
 
 	output, code, err := ch1.Run(context.TODO(), "master")

--- a/runner/fixture/combined.ps1
+++ b/runner/fixture/combined.ps1
@@ -1,0 +1,2 @@
+Write-Output "STDOUT"
+$host.UI.WriteErrorLine('STDERR')

--- a/vendor/github.com/dcos/dcos-go/dcos/constants.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/constants.go
@@ -1,5 +1,9 @@
 package dcos
 
+import (
+	"runtime"
+)
+
 // DC/OS roles.
 const (
 	// RoleMaster defines a master role.
@@ -12,11 +16,15 @@ const (
 	RoleAgentPublic = "agent_public"
 )
 
-// DC/OS files.
-const (
-	// FileDetectIP is a shell script on every DC/OS node which provides IP address used by mesos.
-	FileDetectIP = "/opt/mesosphere/bin/detect_ip"
-)
+// GetFileDetectIPLocation is a shell script on every DC/OS node which provides IP address used by mesos.
+func GetFileDetectIPLocation() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "/mesos/bin/detect_ip.ps1"
+	default:
+		return "/opt/mesosphere/bin/detect_ip"
+	}
+}
 
 // DC/OS DNS records.
 const (

--- a/vendor/github.com/dcos/dcos-go/dcos/nodeutil/README.md
+++ b/vendor/github.com/dcos/dcos-go/dcos/nodeutil/README.md
@@ -10,6 +10,8 @@ dcos-go/dcos/nodeutil provides a golang interface to DC/OS cluster.
 - `MesosID(*context.Context)` returns a node's mesos ID. Optionally can accept an instance of Context to control
   request cancellation from a caller.
 - `ClusterID()` returns a UUID of a cluster.
+- `TaskCanonicalID(context.Context, task)` returns a canonical node ID for a given task.
+  This includes the mesos agent, framework, executor and container IDs.
 
 Note: Methods `IsLeader()` and `ClusterID()` will only work on master nodes.
 
@@ -57,4 +59,3 @@ func main() {
     }
 }
 ```
-

--- a/vendor/github.com/dcos/dcos-go/dcos/nodeutil/mesos.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/nodeutil/mesos.go
@@ -1,0 +1,85 @@
+package nodeutil
+
+import "errors"
+
+// ErrContainerIDNotFound is returned by ContainerIDs() function if the container id is not set.
+var ErrContainerIDNotFound = errors.New("invalid task. Container ID not found")
+
+// State stands for mesos state.json available via /mesos/master/state.json
+type State struct {
+	ID                  string      `json:"id"`
+	Slaves              []Slave     `json:"slaves"`
+	Frameworks          []Framework `json:"frameworks"`
+	CompletedFrameworks []Framework `json:"completed_frameworks"`
+}
+
+// Slave is a field in state.json
+type Slave struct {
+	ID       string `json:"id"`
+	Hostname string `json:"hostname"`
+	Port     int    `json:"port"`
+	Pid      string `json:"pid"`
+}
+
+// Framework is a field in state.json
+type Framework struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	PID            string `json:"pid"`
+	Role           string `json:"role"`
+	Tasks          []Task `json:"tasks"`
+	CompletedTasks []Task `json:"completed_tasks"`
+}
+
+// Task is a field in state.json
+type Task struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	FrameworkID string `json:"framework_id"`
+	ExecutorID  string `json:"executor_id"`
+	SlaveID     string `json:"slave_id"`
+	State       string `json:"state"`
+	Role        string `json:"role"`
+
+	Statuses []Status `json:"statuses"`
+}
+
+// Status is a field in state.json
+type Status struct {
+	ContainerStatus ContainerStatus `json:"container_status"`
+}
+
+// ContainerStatus is a field in state.json
+type ContainerStatus struct {
+	ContainerID NestedValue `json:"container_id"`
+}
+
+// NestedValue represents a nested container ID. The value is the actual container ID
+// and Parent is a reference to another NestedValue structure.
+type NestedValue struct {
+	Value  string       `json:"value"`
+	Parent *NestedValue `json:"parent"`
+}
+
+// ContainerIDs returns a slice of container ids , starting with the current,
+// and then appending the parent container ids.
+func (t Task) ContainerIDs() (containerIDs []string, err error) {
+	for _, status := range t.Statuses {
+		containerID := status.ContainerStatus.ContainerID.Value
+		if containerID == "" {
+			return nil, ErrContainerIDNotFound
+		}
+		containerIDs = append(containerIDs, containerID)
+
+		parent := status.ContainerStatus.ContainerID.Parent
+		for parent != nil {
+			containerIDs = append(containerIDs, parent.Value)
+			parent = parent.Parent
+		}
+	}
+
+	if len(containerIDs) == 0 {
+		return nil, ErrContainerIDNotFound
+	}
+	return containerIDs, nil
+}

--- a/vendor/github.com/dcos/dcos-go/dcos/nodeutil/util.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/nodeutil/util.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,10 +22,11 @@ import (
 )
 
 const (
-	defaultExecTimeout       = 10 * time.Second
-	defaultClusterIDLocation = "/var/lib/dcos/cluster-id"
-	defaultBashPath          = "/bin/bash"
+	defaultExecTimeout = 10 * time.Second
 )
+
+// ErrTaskNotFound is return if the canonical ID for a given task not found.
+var ErrTaskNotFound = errors.New("task not found")
 
 var defaultStateURL = url.URL{
 	Scheme: "http",
@@ -53,6 +56,16 @@ type NodeInfo interface {
 	IsLeader() (bool, error)
 	MesosID(context.Context) (string, error)
 	ClusterID() (string, error)
+	TaskCanonicalID(ctx context.Context, task string, completed bool) (*CanonicalTaskID, error)
+}
+
+// CanonicalTaskID is a unique task id.
+type CanonicalTaskID struct {
+	ID           string
+	AgentID      string
+	FrameworkID  string
+	ExecutorID   string
+	ContainerIDs []string
 }
 
 // dcosInfo is implementation of NodeInfo interface.
@@ -75,6 +88,24 @@ type dcosInfo struct {
 	mesosStateURL     string
 	dnsRecordLeader   string
 	clusterIDLocation string
+}
+
+func getDefaultShellPath() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "powershell.exe"
+	default:
+		return "/bin/bash"
+	}
+}
+
+func getClusterIDLocation() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "/mesos/var/lib/dcos/cluster-id"
+	default:
+		return "/var/lib/dcos/cluster-id"
+	}
 }
 
 // NewNodeInfo returns a new instance of NodeInfo implementation.
@@ -103,11 +134,11 @@ func NewNodeInfo(client *http.Client, role string, options ...Option) (NodeInfo,
 		client:            client,
 		role:              role,
 		cache:             true,
-		detectIPLocation:  dcos.FileDetectIP,
+		detectIPLocation:  dcos.GetFileDetectIPLocation(),
 		detectIPTimeout:   defaultExecTimeout,
 		dnsRecordLeader:   dcos.DNSRecordLeader,
 		mesosStateURL:     defaultStateURL.String(),
-		clusterIDLocation: defaultClusterIDLocation,
+		clusterIDLocation: getClusterIDLocation(),
 	}
 
 	// update parameters with a caller input.
@@ -140,7 +171,7 @@ func (d *dcosInfo) DetectIP() (net.IP, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.detectIPTimeout)
 	defer cancel()
-	ce, err := exec.Run(ctx, defaultBashPath, []string{d.detectIPLocation})
+	ce, err := exec.Run(ctx, getDefaultShellPath(), []string{d.detectIPLocation})
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +189,12 @@ func (d *dcosInfo) DetectIP() (net.IP, error) {
 	// strip the trailing \n
 	detectedIP := string(bytes.TrimSpace(buf))
 	if detectedIP == "" {
-		return nil, ErrNodeInfo{fmt.Sprintf("command %s return empty output", dcos.FileDetectIP)}
+		return nil, ErrNodeInfo{fmt.Sprintf("command %s return empty output", dcos.GetFileDetectIPLocation())}
 	}
 
 	validIP := net.ParseIP(detectedIP)
 	if validIP == nil {
-		return nil, ErrNodeInfo{fmt.Sprintf("command %s returned invalid IP address %s", dcos.FileDetectIP, detectedIP)}
+		return nil, ErrNodeInfo{fmt.Sprintf("command %s returned invalid IP address %s", dcos.GetFileDetectIPLocation(), detectedIP)}
 	}
 
 	// save retrieved IP address to cache.
@@ -240,44 +271,8 @@ func (d *dcosInfo) MesosID(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	req, err := http.NewRequest("GET", d.mesosStateURL, nil)
+	state, err := d.state(ctx)
 	if err != nil {
-		return "", err
-	}
-
-	if ctx != nil {
-		if header, ok := HeaderFromContext(ctx); ok {
-			req.Header = header
-		}
-		req = req.WithContext(ctx)
-	}
-
-	resp, err := d.client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", ErrNodeInfo{fmt.Sprintf("GET request to %s returned response code %d", d.mesosStateURL, resp.StatusCode)}
-	}
-
-	type stateJSON struct {
-		// top level ID is used for mesos master ID.
-		ID     string `json:"id"`
-		Slaves []struct {
-			ID  string `json:"id"`
-			Pid string `json:"pid"`
-		} `json:"slaves"`
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	var state stateJSON
-	if err := json.Unmarshal(body, &state); err != nil {
 		return "", err
 	}
 
@@ -366,6 +361,91 @@ func (d *dcosInfo) ClusterID() (string, error) {
 	}
 
 	return clusterID, nil
+}
+
+func (d *dcosInfo) state(ctx context.Context) (state State, err error) {
+	req, err := http.NewRequest("GET", d.mesosStateURL, nil)
+	if err != nil {
+		return state, err
+	}
+
+	if ctx != nil {
+		if header, ok := HeaderFromContext(ctx); ok {
+			req.Header = header
+		}
+		req = req.WithContext(ctx)
+	}
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return state, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return state, ErrNodeInfo{fmt.Sprintf("GET request to %s returned response code %d", d.mesosStateURL, resp.StatusCode)}
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&state)
+	return state, err
+}
+
+func findTask(name string, completed bool, frameworks []Framework) (foundTasks []Task) {
+	for _, framework := range frameworks {
+		currentTasks := framework.Tasks
+		if completed {
+			currentTasks = framework.CompletedTasks
+		}
+
+		for _, t := range currentTasks {
+			if t.Name != name && !strings.Contains(t.ID, name) {
+				continue
+			}
+			foundTasks = append(foundTasks, t)
+		}
+	}
+	return
+}
+
+// TaskCanonicalID return a CanonicalTaskID for a given task.
+func (d *dcosInfo) TaskCanonicalID(ctx context.Context, task string, completed bool) (*CanonicalTaskID, error) {
+	state, err := d.state(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	frameworksTasks := findTask(task, completed, state.Frameworks)
+
+	var completedFrameworksTasks []Task
+	if completed {
+		completedFrameworksTasks = findTask(task, completed, state.CompletedFrameworks)
+	}
+
+	foundTasks := append(frameworksTasks, completedFrameworksTasks...)
+
+	if len(foundTasks) == 0 {
+		return nil, ErrTaskNotFound
+	} else if len(foundTasks) > 1 {
+		var taskIDs []string
+		for _, task := range foundTasks {
+			taskIDs = append(taskIDs, task.ID)
+		}
+		return nil, fmt.Errorf("found more then 1 task with name %s: %s", task, taskIDs)
+	}
+
+	t := foundTasks[0]
+	containerIDs, err := t.ContainerIDs()
+	if err != nil {
+		return nil, err
+	}
+
+	return &CanonicalTaskID{
+		ID:           t.ID,
+		AgentID:      t.SlaveID,
+		FrameworkID:  t.FrameworkID,
+		ExecutorID:   t.ExecutorID,
+		ContainerIDs: containerIDs,
+	}, nil
 }
 
 // HeaderFromContext returns http.Header from a context if it's found.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -32,10 +32,10 @@
 			"revisionTime": "2016-10-26T22:29:26Z"
 		},
 		{
-			"checksumSHA1": "t+xHkFcaPuAVgec1W3MNTnSNhXg=",
+			"checksumSHA1": "nQca8pxnWNzJAUXaWErBIrD0NVI=",
 			"path": "github.com/dcos/dcos-go/dcos",
-			"revision": "74526af763e046fdbcb9e2ac64fed0bdd9213e0f",
-			"revisionTime": "2017-02-23T00:15:14Z"
+			"revision": "9604451b7bdc14f3634699788b829a6e5550200c",
+			"revisionTime": "2017-12-26T21:09:29Z"
 		},
 		{
 			"checksumSHA1": "Qz6GSjmNYD4CiTapDBqbkFAJYCI=",
@@ -44,16 +44,20 @@
 			"revisionTime": "2017-01-19T15:54:30Z"
 		},
 		{
-			"checksumSHA1": "hjwc/7iAxSRM7Aw9UPg7x1epu40=",
+			"checksumSHA1": "TvAPETutA39fbqmYOSm+nKUYzoA=",
 			"path": "github.com/dcos/dcos-go/dcos/nodeutil",
-			"revision": "4b59fd44c61148e7f94b3e75acb9834a15682ee9",
-			"revisionTime": "2017-05-17T21:25:13Z"
+			"revision": "9604451b7bdc14f3634699788b829a6e5550200c",
+			"revisionTime": "2017-12-26T21:09:29Z"
 		},
 		{
-			"checksumSHA1": "W0wH0RfIh+0JdimLuEuqcHB/mGI=",
+			"checksumSHA1": "uO4xxqlcKEQXzUUZ+fOupIhFVq4=",
 			"path": "github.com/dcos/dcos-go/exec",
-			"revision": "8275c8424624c6c450e600b7669adb7dc7dd67c9",
-			"revisionTime": "2017-07-21T00:17:51Z"
+			"revision": "8d36a4f0bf86f5fe43575aff9ac81c6b552770d5",
+			"revisionTime": "2017-08-18T21:00:21Z"
+		},
+		{
+			"path": "github.com/dcos/dcos-go/exec/nodeutil",
+			"revision": ""
 		},
 		{
 			"checksumSHA1": "JhJJQCCXRHfkWYtlYjp6p2WE5Hs=",


### PR DESCRIPTION
This PR is to enable DCOS-Diagnostics to support agent role a Windows agent node inside a  DC/OS cluster with Windows nodes

Changes in this PR include:
1. All the necessary changes needed for successful building Windows version of dcos-diagnostics.exe
2. Changes for making sure all unitests (mainly under api and  runner subdirs) passed
3. Added logics for supporting /system/health/v1 endpoint with information collected/queried from interacting with Windows Service Control Manager on installed DC/OS services state  

     Other than the existing unittests, changes in the PR was tested on in the following scenario:
dcos-diagnostics.exe ran as an agent in daemon mode  on a Windows agent node inside a hybrid DC/OS cluster with Linux and Windows agent nodes.  In the DC/OS UI, the correct healthy states (expected healthy or unhealthy) was shown for each Windows agent node.