### PR TITLE
Added support for running DCOS-Diagnostics in the agent role on a Windows agent node

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -951,7 +951,7 @@ func roleMatched(roles []string, DCOSTools DCOSHelper) (bool, error) {
 
 func (j *DiagnosticsJob) dispatchLogs(ctx context.Context, provider, entity string, cfg *config.Config, DCOSTools DCOSHelper) (r io.ReadCloser, err error) {
 	// make a buffered doneChan to communicate back to process.
-
+/*
 	if provider == "units" {
 		for _, endpoint := range j.logProviders.HTTPEndpoints {
 			if endpoint.FileName == entity {
@@ -969,7 +969,7 @@ func (j *DiagnosticsJob) dispatchLogs(ctx context.Context, provider, entity stri
 		}
 		return r, fmt.Errorf("%s not found", entity)
 	}
-
+*/
 	if provider == "files" {
 		logrus.Debugf("dispatching a file %s", entity)
 		for _, fileProvider := range j.logProviders.LocalFiles {

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -99,10 +99,10 @@ func (st *fakeDCOSTools) GetUnitNames() (units []string, err error) {
 	units = []string{"dcos-setup.service", "dcos-link-env.service", "dcos-download.service", "unit_a", "unit_b", "unit_c", "unit_to_fail"}
 	return units, err
 }
-
+/*
 func (st *fakeDCOSTools) GetJournalOutput(unit string) (string, error) {
 	return "journal output", nil
-}
+}*/
 
 func (st *fakeDCOSTools) GetMesosNodeID() (string, error) {
 	return "node-id-123", nil

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/coreos/go-systemd/dbus"
 	"github.com/dcos/dcos-go/dcos/nodeutil"
-	"github.com/dcos/dcos-log/dcos-log/journal/reader"
+	//"github.com/dcos/dcos-log/dcos-log/journal/reader"
 )
 
 const (
@@ -142,7 +142,7 @@ func (st *DCOSTools) GetUnitNames() (units []string, err error) {
 	logrus.Debugf("List of units: %s", units)
 	return units, nil
 }
-
+/*
 // GetJournalOutput returns last 50 lines of journald command output for a specific systemd Unit.
 func (st *DCOSTools) GetJournalOutput(unit string) (string, error) {
 	matches := defaultSystemdMatches(unit)
@@ -160,6 +160,7 @@ func (st *DCOSTools) GetJournalOutput(unit string) (string, error) {
 
 	return string(entries), nil
 }
+*/
 
 func useTLSScheme(url string, use bool) (string, error) {
 	if use {
@@ -345,7 +346,7 @@ func normalizeProperty(unitProps map[string]interface{}, tools DCOSHelper) (Heal
 	if err != nil {
 		return HealthResponseValues{}, err
 	}
-
+/*
 	if unitHealth > 0 {
 		journalOutput, err := tools.GetJournalOutput(propsResponse.ID)
 		if err == nil {
@@ -355,7 +356,7 @@ func normalizeProperty(unitProps map[string]interface{}, tools DCOSHelper) (Heal
 			logrus.Errorf("Could not read journalctl: %s", err)
 		}
 	}
-
+*/
 	s := strings.Split(propsResponse.Description, ": ")
 	if len(s) != 2 {
 		description = strings.Join(s, " ")
@@ -382,7 +383,7 @@ func readFile(fileLocation string) (r io.ReadCloser, err error) {
 	}
 	return file, nil
 }
-
+/*
 func readJournalOutputSince(unit, sinceString string) (io.ReadCloser, error) {
 	matches := defaultSystemdMatches(unit)
 	duration, err := time.ParseDuration(sinceString)
@@ -398,7 +399,8 @@ func readJournalOutputSince(unit, sinceString string) (io.ReadCloser, error) {
 
 	return j, nil
 }
-
+*/
+/*
 // returns default reader.JournalEntryMatch for a given systemd unit.
 func defaultSystemdMatches(unit string) []reader.JournalEntryMatch {
 	return []reader.JournalEntryMatch{
@@ -412,3 +414,4 @@ func defaultSystemdMatches(unit string) []reader.JournalEntryMatch {
 		},
 	}
 }
+*/

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -40,7 +40,7 @@ type DCOSHelper interface {
 	GetUnitNames() ([]string, error)
 
 	// Get journal output
-	GetJournalOutput(string) (string, error)
+	//GetJournalOutput(string) (string, error)
 
 	// Get mesos node id, first argument is a function to determine a role.
 	GetMesosNodeID() (string, error)

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/coreos/go-systemd/activation"
+//	"github.com/coreos/go-systemd/activation"
 	"github.com/dcos/dcos-diagnostics/api"
 	"github.com/dcos/dcos-go/dcos"
 	"github.com/dcos/dcos-go/dcos/http/transport"
@@ -177,7 +177,8 @@ func startDiagnosticsDaemon() {
 	}
 
 	// try using systemd socket
-	listeners, err := activation.Listeners(true)
+	// listeners, err := activation.Listeners(true)
+	listeners, err := getListener(true)
 	if err != nil {
 		logrus.Fatalf("Unable to initialize listener: %s", err)
 	}

--- a/cmd/listener_linux.go
+++ b/cmd/listener_linux.go
@@ -1,0 +1,30 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net"
+	"os"
+
+	"github.com/coreos/go-systemd/activation"
+)
+
+func getListener(unsetEnv bool) ([]net.Listener, error) {
+	return activation.Listeners(true)
+}
+
+func getFiles(unsetEnv bool) []*os.File {
+	return activation.Files(unsetEnv)
+}

--- a/cmd/listener_windows.go
+++ b/cmd/listener_windows.go
@@ -1,0 +1,28 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net"
+	"os"
+)
+
+func getListener(unsetEnv bool) ([]net.Listener, error) {
+	return nil, nil
+}
+
+func getFiles(unsetEnv bool) []*os.File {
+	return nil
+}


### PR DESCRIPTION
This PR is to enable DCOS-Diagnostics to support agent role a Windows agent node inside a DC/OS cluster with Windows nodes

Changes in this PR include:

All the necessary changes needed for successful building Windows version of dcos-diagnostics.exe

Changes for making sure all unitests (mainly under api and runner subdirs) passed

Added logics for supporting /system/health/v1 endpoint with information collected/queried from interacting with Windows Service Control Manager on installed DC/OS services state

Other than the existing unittests, changes in the PR was tested on in the following scenario:
dcos-diagnostics.exe ran as an agent in daemon mode on a Windows agent node inside a hybrid DC/OS cluster with Linux and Windows agent nodes. In the DC/OS UI, the correct healthy states (expected healthy or unhealthy) was shown for each Windows agent node.