### PR TITLE
runner: treat command timeout as a failed check

### DIFF
--- a/runner/check.go
+++ b/runner/check.go
@@ -90,7 +90,7 @@ func (c *Check) verifyRole(role string) bool {
 // against hardcoded string. see https://golang.org/src/os/exec_posix.go Line 85
 func (c Check) checkTimeout(e error) bool {
 	if exiterr, ok := e.(*goexec.ExitError); ok {
-		return "signal: killed" == exiterr.Error()
+		return signalKilled == exiterr.Error()
 	}
 
 	return false


### PR DESCRIPTION
[DCOS_OSS-2247](https://jira.mesosphere.com/browse/DCOS_OSS-2247)

there are several levels of errors when runner executes checks. The error
is considered to be an exception, where runner is unable to run the checks for
some reason. For example, when the check is not present in the path.
However if the command execution takes more time then defined in `timeout`
check property, it will be killed and also considered as an error. But in fact,
it should be a failed check. This PR fixes it.