### PR TITLE
 Skipped TestTimeout test, use the detect_ip file in the default path for Windows and Added Unit failures status for missing units on Windows

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -19,8 +19,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
-	"runtime"
 	"strconv"
 
 	"github.com/Sirupsen/logrus"
@@ -36,7 +34,6 @@ const (
 	diagnosticsBundleDir      = "/var/run/dcos/dcos-diagnostics/diagnostic_bundles"
 	diagnosticsEndpointConfig = "/opt/mesosphere/etc/endpoints_config.json"
 	exhibitorURL              = "http://127.0.0.1:8181/exhibitor/v1/cluster/status"
-	detectIPScriptPath        = "\\DCOS\\diagnostics\\detect_ip.ps1"
 )
 
 // override the defaultStateURL to use https scheme
@@ -130,9 +127,6 @@ func startDiagnosticsDaemon() {
 	var options []nodeutil.Option
 	if defaultConfig.FlagForceTLS {
 		options = append(options, nodeutil.OptionMesosStateURL(defaultStateURL.String()))
-	}
-	if runtime.GOOS == "windows" {
-		options = append(options, nodeutil.OptionDetectIP(os.Getenv("SYSTEMDRIVE")+detectIPScriptPath))
 	}
 
 	nodeInfo, err := nodeutil.NewNodeInfo(client, defaultConfig.FlagRole, options...)

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"encoding/json"
+
 	"github.com/pkg/errors"
 )
 
@@ -67,7 +68,7 @@ func TestRun(t *testing.T) {
 	var expectedOutput string
 	if runtime.GOOS == "windows" {
 		cfg = strings.Replace(cfg, "CombinedScriptName", CombinedPowershellScript, -1)
-		expectedOutput = "STDOUT\r\nSTDERR\r\n"	
+		expectedOutput = "STDOUT\r\nSTDERR\r\n"
 	} else {
 		cfg = strings.Replace(cfg, "CombinedScriptName", CombinedShScript, -1)
 		expectedOutput = "STDOUT\nSTDERR\n"
@@ -231,6 +232,10 @@ func TestTimeout(t *testing.T) {
     "poststart": ["check1", "check2"]
   }
 }`
+
+	if runtime.GOOS == "windows" {
+		t.Skip("TestTimeout was skipped on Windows")
+	}
 	err := r.Load(strings.NewReader(cfg))
 	if err != nil {
 		t.Fatal(err)
@@ -249,9 +254,9 @@ func TestTimeout(t *testing.T) {
 
 	type expectedOutput struct {
 		Status int `json:"status"`
-		Checks map[string] struct {
+		Checks map[string]struct {
 			Output string `json:"output"`
-			Status int `json:"status"`
+			Status int    `json:"status"`
 		} `json:"checks"`
 	}
 

--- a/vendor/github.com/dcos/dcos-go/dcos/nodeutil/util.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/nodeutil/util.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	defaultExecTimeout = 10 * time.Second
+	defaultExecTimeout       = 10 * time.Second
+	defaultClusterIDLocation = "/var/lib/dcos/cluster-id"
 )
 
 // ErrTaskNotFound is return if the canonical ID for a given task not found.
@@ -99,15 +100,6 @@ func getDefaultShellPath() string {
 	}
 }
 
-func getClusterIDLocation() string {
-	switch runtime.GOOS {
-	case "windows":
-		return "/mesos/var/lib/dcos/cluster-id"
-	default:
-		return "/var/lib/dcos/cluster-id"
-	}
-}
-
 // NewNodeInfo returns a new instance of NodeInfo implementation.
 func NewNodeInfo(client *http.Client, role string, options ...Option) (NodeInfo, error) {
 	if client == nil {
@@ -138,7 +130,7 @@ func NewNodeInfo(client *http.Client, role string, options ...Option) (NodeInfo,
 		detectIPTimeout:   defaultExecTimeout,
 		dnsRecordLeader:   dcos.DNSRecordLeader,
 		mesosStateURL:     defaultStateURL.String(),
-		clusterIDLocation: getClusterIDLocation(),
+		clusterIDLocation: defaultClusterIDLocation,
 	}
 
 	// update parameters with a caller input.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -50,10 +50,10 @@
 			"revisionTime": "2017-01-19T15:54:30Z"
 		},
 		{
-			"checksumSHA1": "TvAPETutA39fbqmYOSm+nKUYzoA=",
+			"checksumSHA1": "59TTuicR7fFqMWZ+8chOcynF1Vo=",
 			"path": "github.com/dcos/dcos-go/dcos/nodeutil",
-			"revision": "9604451b7bdc14f3634699788b829a6e5550200c",
-			"revisionTime": "2017-12-26T21:09:29Z"
+			"revision": "95000f9090913360b907002f4a38f30ab077c5ee",
+			"revisionTime": "2018-05-12T14:06:00Z"
 		},
 		{
 			"checksumSHA1": "uO4xxqlcKEQXzUUZ+fOupIhFVq4=",


### PR DESCRIPTION
This PR contains three separate commits that address the following three issues.
1. Skipped TestTimeout test
2.Made the dcos-diagnostics to use the detect_ip file in the default path for Windows
3. Added Unit failures status for missing units on Windows
