### PR TITLE
Run tests against the config and cmd packages

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -16,7 +16,7 @@ set -o pipefail
 export PATH="${GOPATH}/bin:${PATH}"
 
 PACKAGES="$(go list ./... | grep -v /vendor/)"
-SUBDIRS="api"
+SUBDIRS="api config cmd"
 SOURCE_DIR=$(git rev-parse --show-toplevel)
 BUILD_DIR="${SOURCE_DIR}/build"
 


### PR DESCRIPTION
This updates the test script to run tests and linting against the `config` and `cmd` packages in this project.

I verified the fix locally by adding unnecessary newlines to the end of `config/config.go` and running `make test` with and without this patch. `make test` reports the extra newlines and fails with this patch, and ignores them without it.