### PR TITLE
Update golint url

### DIFF
--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -78,7 +78,7 @@ function _goimports()
 function _golint()
 {
     logmsg("Running 'golint' ...")
-    & go get -u github.com/golang/lint/
+    & go get -u github.com/golang/lint/golint
     
     $text = & golint -set_exit_status  $PACKAGES
     fastfail("failed to run golint: $text")


### PR DESCRIPTION
DC/OS Diagnostics tests for Windows are showing errors

` go get -u github.com/golang/lint `  fails to retrieve the golint package

updated the URL to point to the correct address
