### PR TITLE
Add error checking for coverage unit tests

### DIFF
--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -79,7 +79,8 @@ function _golint()
 {
     logmsg("Running 'golint' ...")
     & go get -u github.com/golang/lint/golint
-    
+    fastfail("failed to get golint")
+
     $text = & golint -set_exit_status  $PACKAGES
     fastfail("failed to run golint: $text")
 
@@ -105,7 +106,8 @@ function _govet()
 
 function _unittest_with_coverage {
     logmsg "Running 'go test' ..."
-    go test -cover -race -v $PACKAGES
+    $text = & go test -cover -race -v $PACKAGES
+    fastfail("failed to run go test: $text") 
 }
 
 # Main.


### PR DESCRIPTION
Issue: There is no error checking for function _unittest_with_coverage
Added a $LASTEXITCODE check