### PR TITLE
Fix command description

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -46,13 +46,7 @@ var defaultStateURL = url.URL{
 // daemonCmd represents the daemon command
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Start an http server and polls the components health.",
 	Run: func(cmd *cobra.Command, args []string) {
 		startDiagnosticsDaemon()
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,6 @@ var RootCmd = &cobra.Command{
 	Long: `DC/OS diagnostics service provides health information about cluster.
 
 dcos-diagnostics daemon start an http server and polls the components health.
-dcos-diagnostics check provides CLI functionality to run checks on DC/OS cluster.
 `,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:


### PR DESCRIPTION
The description of `daemon` was copied from cobra example
and has noting to do with this project.
Long description for help has invalid command `check` which is not
implemented.