### PR TITLE
Minor code improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3
+FROM golang:1.11.0
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -275,7 +275,7 @@ func (j *DiagnosticsJob) runBackgroundJob(nodes []Node) {
 		}
 
 		updateSummaryReport("START collecting logs", node, "", summaryReport)
-		url := fmt.Sprintf("http://%s:%d%s/logs", node.IP, port, BaseRoute)
+		url := fmt.Sprintf("http://%s:%d%s/logs", node.IP, port, baseRoute)
 		endpoints := make(map[string]string)
 		body, statusCode, err := j.DCOSTools.Get(url, time.Second*3)
 		if err != nil {
@@ -361,7 +361,7 @@ func (j *DiagnosticsJob) delete(bundleName string) (response diagnosticsReportRe
 		return prepareResponseWithErr(http.StatusServiceUnavailable, err)
 	}
 	if ok {
-		url := fmt.Sprintf("http://%s:%d%s/report/diagnostics/delete/%s", node, j.Cfg.FlagMasterPort, BaseRoute, bundleName)
+		url := fmt.Sprintf("http://%s:%d%s/report/diagnostics/delete/%s", node, j.Cfg.FlagMasterPort, baseRoute, bundleName)
 		j.Status = "Attempting to delete a bundle on a remote host. POST " + url
 		logrus.Debug(j.Status)
 		timeout := time.Second * 5
@@ -416,7 +416,7 @@ func (j *DiagnosticsJob) getStatusAll() (map[string]bundleReportStatus, error) {
 
 	for _, master := range masterNodes {
 		var status bundleReportStatus
-		url := fmt.Sprintf("http://%s:%d%s/report/diagnostics/status", master.IP, j.Cfg.FlagMasterPort, BaseRoute)
+		url := fmt.Sprintf("http://%s:%d%s/report/diagnostics/status", master.IP, j.Cfg.FlagMasterPort, baseRoute)
 		body, _, err := j.DCOSTools.Get(url, time.Second*3)
 		if err != nil {
 			logrus.WithError(err).WithField("URL", url).Error("Could not get data")
@@ -615,7 +615,7 @@ func (j *DiagnosticsJob) cancel() (response diagnosticsReportResponse, err error
 		j.cancelChan <- true
 		logrus.Debug("Cancelling a local job")
 	} else {
-		url := fmt.Sprintf("http://%s:%d%s/report/diagnostics/cancel", node, j.Cfg.FlagMasterPort, BaseRoute)
+		url := fmt.Sprintf("http://%s:%d%s/report/diagnostics/cancel", node, j.Cfg.FlagMasterPort, baseRoute)
 		j.Status = "Attempting to cancel a job on a remote host. POST " + url
 		logrus.Debug(j.Status)
 		response, _, err := j.DCOSTools.Post(url, time.Duration(j.Cfg.FlagDiagnosticsJobGetSingleURLTimeoutMinutes)*time.Minute)
@@ -654,7 +654,7 @@ func listAllBundles(cfg *config.Config, DCOSTools DCOSHelper) (map[string][]bund
 	}
 	for _, master := range masterNodes {
 		var bundleUrls []bundle
-		url := fmt.Sprintf("http://%s:%d%s/report/diagnostics/list", master.IP, cfg.FlagMasterPort, BaseRoute)
+		url := fmt.Sprintf("http://%s:%d%s/report/diagnostics/list", master.IP, cfg.FlagMasterPort, baseRoute)
 		body, _, err := DCOSTools.Get(url, time.Second*3)
 		if err != nil {
 			logrus.Errorf("Could not HTTP GET %s: %s", url, err)
@@ -833,7 +833,7 @@ func loadInternalProviders(cfg *config.Config, DCOSTools DCOSHelper) (internalCo
 	for _, unit := range append(units, cfg.SystemdUnits...) {
 		httpEndpoints = append(httpEndpoints, HTTPProvider{
 			Port:     port,
-			URI:      fmt.Sprintf("%s/logs/units/%s", BaseRoute, unit),
+			URI:      fmt.Sprintf("%s/logs/units/%s", baseRoute, unit),
 			FileName: unit,
 		})
 	}
@@ -841,7 +841,7 @@ func loadInternalProviders(cfg *config.Config, DCOSTools DCOSHelper) (internalCo
 	// add dcos-diagnostics health report.
 	httpEndpoints = append(httpEndpoints, HTTPProvider{
 		Port:     port,
-		URI:      BaseRoute,
+		URI:      baseRoute,
 		FileName: "dcos-diagnostics-health.json",
 	})
 
@@ -896,7 +896,7 @@ func (j *DiagnosticsJob) getLogsEndpoints() (endpoints map[string]string, err er
 		if !matchRole(currentRole, file.Role) {
 			continue
 		}
-		endpoints[file.Location] = fmt.Sprintf(":%d%s/logs/files/%s", port, BaseRoute, file.sanitizedLocation)
+		endpoints[file.Location] = fmt.Sprintf(":%d%s/logs/files/%s", port, baseRoute, file.sanitizedLocation)
 	}
 
 	// command endpoints
@@ -905,7 +905,7 @@ func (j *DiagnosticsJob) getLogsEndpoints() (endpoints map[string]string, err er
 			continue
 		}
 		if c.indexedCommand != "" {
-			endpoints[c.indexedCommand] = fmt.Sprintf(":%d%s/logs/cmds/%s", port, BaseRoute, c.indexedCommand)
+			endpoints[c.indexedCommand] = fmt.Sprintf(":%d%s/logs/cmds/%s", port, baseRoute, c.indexedCommand)
 		}
 	}
 	return endpoints, nil

--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -19,9 +19,9 @@ import (
 func TestFindRequestedNodes(t *testing.T) {
 	tools := &fakeDCOSTools{}
 	dt := &Dt{
-		Cfg:              testCfg,
+		Cfg:              testCfg(),
 		DtDCOSTools:      tools,
-		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg, DCOSTools: tools},
+		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg(), DCOSTools: tools},
 		MR:               &MonitoringResponse{},
 	}
 
@@ -107,23 +107,24 @@ func TestFindRequestedNodes(t *testing.T) {
 
 func TestGetStatus(t *testing.T) {
 	tools := &fakeDCOSTools{}
+	config := testCfg()
 	dt := &Dt{
-		Cfg:              testCfg,
+		Cfg:              config,
 		DtDCOSTools:      tools,
-		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg, DCOSTools: tools},
+		DtDiagnosticsJob: &DiagnosticsJob{Cfg: config, DCOSTools: tools},
 		MR:               &MonitoringResponse{},
 	}
 
 	status := dt.DtDiagnosticsJob.getStatus()
-	assert.Equal(t, status.DiagnosticBundlesBaseDir, DiagnosticsBundleDir)
+	assert.Equal(t, status.DiagnosticBundlesBaseDir, config.FlagDiagnosticsBundleDir)
 }
 
 func TestGetAllStatus(t *testing.T) {
 	tools := &fakeDCOSTools{}
 	dt := &Dt{
-		Cfg:              testCfg,
+		Cfg:              testCfg(),
 		DtDCOSTools:      tools,
-		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg, DCOSTools: tools},
+		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg(), DCOSTools: tools},
 		MR:               &MonitoringResponse{},
 	}
 
@@ -169,9 +170,9 @@ func TestGetAllStatus(t *testing.T) {
 func TestIsSnapshotAvailable(t *testing.T) {
 	tools := &fakeDCOSTools{}
 	dt := &Dt{
-		Cfg:              testCfg,
+		Cfg:              testCfg(),
 		DtDCOSTools:      tools,
-		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg, DCOSTools: tools},
+		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg(), DCOSTools: tools},
 		MR:               &MonitoringResponse{},
 	}
 
@@ -198,9 +199,9 @@ func TestIsSnapshotAvailable(t *testing.T) {
 func TestCancelNotRunningJob(t *testing.T) {
 	tools := &fakeDCOSTools{}
 	dt := &Dt{
-		Cfg:              testCfg,
+		Cfg:              testCfg(),
 		DtDCOSTools:      tools,
-		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg, DCOSTools: tools},
+		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg(), DCOSTools: tools},
 		MR:               &MonitoringResponse{},
 	}
 	router := NewRouter(dt)
@@ -246,9 +247,9 @@ func TestCancelNotRunningJob(t *testing.T) {
 func TestCancelGlobalJob(t *testing.T) {
 	tools := &fakeDCOSTools{}
 	dt := &Dt{
-		Cfg:              testCfg,
+		Cfg:              testCfg(),
 		DtDCOSTools:      tools,
-		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg, DCOSTools: tools},
+		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg(), DCOSTools: tools},
 		MR:               &MonitoringResponse{},
 	}
 	router := NewRouter(dt)
@@ -303,9 +304,9 @@ func TestCancelGlobalJob(t *testing.T) {
 func TestCancelLocalJob(t *testing.T) {
 	tools := &fakeDCOSTools{}
 	dt := &Dt{
-		Cfg:              testCfg,
+		Cfg:              testCfg(),
 		DtDCOSTools:      tools,
-		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg, DCOSTools: tools},
+		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg(), DCOSTools: tools},
 		MR:               &MonitoringResponse{},
 	}
 	router := NewRouter(dt)
@@ -331,9 +332,9 @@ func TestCancelLocalJob(t *testing.T) {
 func TestFailRunSnapshotJob(t *testing.T) {
 	tools := &fakeDCOSTools{}
 	dt := &Dt{
-		Cfg:              testCfg,
+		Cfg:              testCfg(),
 		DtDCOSTools:      tools,
-		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg, DCOSTools: tools},
+		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg(), DCOSTools: tools},
 		MR:               &MonitoringResponse{},
 	}
 	router := NewRouter(dt)
@@ -377,9 +378,9 @@ func TestFailRunSnapshotJob(t *testing.T) {
 func TestRunSnapshot(t *testing.T) {
 	tools := &fakeDCOSTools{}
 	dt := &Dt{
-		Cfg:              testCfg,
+		Cfg:              testCfg(),
 		DtDCOSTools:      tools,
-		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg, DCOSTools: tools},
+		DtDiagnosticsJob: &DiagnosticsJob{Cfg: testCfg(), DCOSTools: tools},
 		MR:               &MonitoringResponse{},
 	}
 	router := NewRouter(dt)
@@ -411,7 +412,7 @@ func TestRunSnapshot(t *testing.T) {
 	err := json.Unmarshal(response, &responseJSON)
 	assert.NoError(t, err)
 
-	bundle := DiagnosticsBundleDir + "/" + responseJSON.Extra.LastBundleFile
+	bundle := dt.Cfg.FlagDiagnosticsBundleDir + "/" + responseJSON.Extra.LastBundleFile
 	defer func() {
 		err := os.Remove(bundle)
 		assert.NoError(t, err)
@@ -427,7 +428,7 @@ func TestRunSnapshot(t *testing.T) {
 
 	assert.True(t, waitForBundle(t, router))
 
-	snapshotFiles, err := ioutil.ReadDir(DiagnosticsBundleDir)
+	snapshotFiles, err := ioutil.ReadDir(dt.Cfg.FlagDiagnosticsBundleDir)
 	assert.NoError(t, err)
 	assert.True(t, len(snapshotFiles) > 0)
 

--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -127,7 +127,7 @@ func TestGetAllStatus(t *testing.T) {
 		MR:               &MonitoringResponse{},
 	}
 
-	url := fmt.Sprintf("http://127.0.0.1:1050%s/report/diagnostics/status", BaseRoute)
+	url := fmt.Sprintf("http://127.0.0.1:1050%s/report/diagnostics/status", baseRoute)
 	mockedResponse := `
 			{
 			  "is_running":true,
@@ -175,7 +175,7 @@ func TestIsSnapshotAvailable(t *testing.T) {
 		MR:               &MonitoringResponse{},
 	}
 
-	url := fmt.Sprintf("http://127.0.0.1:1050%s/report/diagnostics/list", BaseRoute)
+	url := fmt.Sprintf("http://127.0.0.1:1050%s/report/diagnostics/list", baseRoute)
 	mockedResponse := `[{"file_name": "/system/health/v1/report/diagnostics/serve/bundle-2016-05-13T22:11:36.zip", "file_size": 123}]`
 
 	tools.makeMockedResponse(url, []byte(mockedResponse), http.StatusOK, nil)
@@ -205,7 +205,7 @@ func TestCancelNotRunningJob(t *testing.T) {
 	}
 	router := NewRouter(dt)
 
-	url := fmt.Sprintf("http://127.0.0.1:1050%s/report/diagnostics/status", BaseRoute)
+	url := fmt.Sprintf("http://127.0.0.1:1050%s/report/diagnostics/status", baseRoute)
 	mockedResponse := `
 			{
 			  "is_running":false,
@@ -338,7 +338,7 @@ func TestFailRunSnapshotJob(t *testing.T) {
 	}
 	router := NewRouter(dt)
 
-	url := fmt.Sprintf("http://127.0.0.1:1050%s/report/diagnostics/status", BaseRoute)
+	url := fmt.Sprintf("http://127.0.0.1:1050%s/report/diagnostics/status", baseRoute)
 	mockedResponse := `
 			{
 			  "is_running":false,

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -320,7 +320,7 @@ func listAvailableLocalBundlesFilesHandler(w http.ResponseWriter, r *http.Reques
 		}
 
 		localBundles = append(localBundles, bundle{
-			File: fmt.Sprintf("%s/report/diagnostics/serve/%s", BaseRoute, baseFile),
+			File: fmt.Sprintf("%s/report/diagnostics/serve/%s", baseRoute, baseFile),
 			Size: fileInfo.Size(),
 		})
 	}

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -127,7 +127,7 @@ func (st *fakeDCOSTools) Get(url string, timeout time.Duration) (body []byte, st
 	}
 	var response string
 	// master
-	if url == fmt.Sprintf("http://127.0.0.1:1050%s", BaseRoute) {
+	if url == fmt.Sprintf("http://127.0.0.1:1050%s", baseRoute) {
 		response = `
 			{
 			  "units": [
@@ -158,7 +158,7 @@ func (st *fakeDCOSTools) Get(url string, timeout time.Duration) (body []byte, st
 	}
 
 	// agent
-	if url == fmt.Sprintf("http://127.0.0.2:1050%s", BaseRoute) {
+	if url == fmt.Sprintf("http://127.0.0.2:1050%s", baseRoute) {
 		response = `
 			{
 			  "units": [

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -19,17 +19,16 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-var DiagnosticsBundleDir = "/tmp/snapshot-test"
-var testCfg *config.Config
 
-func init() {
-	if runtime.GOOS == "windows" {
-		DiagnosticsBundleDir = os.Getenv("SYSTEMDRIVE") + "\\tmp\\snapshot-test"
+func testCfg() *config.Config {
+	diagnosticsBundleDir, err := ioutil.TempDir("", "diagnostic-bundle")
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	testCfg = &config.Config{
+	return &config.Config{
 		FlagRole:                 "master",
-		FlagDiagnosticsBundleDir: DiagnosticsBundleDir,
+		FlagDiagnosticsBundleDir: diagnosticsBundleDir,
 		FlagPort:                 1050,
 		FlagMasterPort:           1050,
 	}
@@ -246,7 +245,7 @@ type HandlersTestSuit struct {
 func (s *HandlersTestSuit) SetupTest() {
 	// setup variables
 	s.dt = &Dt{
-		Cfg:         testCfg,
+		Cfg:         testCfg(),
 		DtDCOSTools: &fakeDCOSTools{},
 		MR:          &MonitoringResponse{},
 	}

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -20,24 +20,6 @@ const (
 	unitProperty        = "UNIT"
 )
 
-/*
-// DCOSTools is implementation of DCOSHelper interface.
-type DCOSTools struct {
-	sync.Mutex
-
-	ExhibitorURL string
-	Role         string
-	ForceTLS     bool
-	NodeInfo     nodeutil.NodeInfo
-	Transport    http.RoundTripper
-
-	dcon     *dbus.Conn
-	hostname string
-	ip       string
-	mesosID  string
-}
-*/
-
 // GetHostname return a localhost hostname.
 func (st *DCOSTools) GetHostname() (string, error) {
 	if st.hostname != "" {

--- a/api/helpers_windows.go
+++ b/api/helpers_windows.go
@@ -195,14 +195,14 @@ func normalizeProperty(unitProps map[string]interface{}, tools DCOSHelper) (Heal
 	}, nil
 }
 
-// CheckUnitHealth tells if the Unit is healthy
-func (u *UnitPropertiesResponse) CheckUnitHealth() (int, string, error) {
+// CheckUnitHealth tells if the Unit is Healthy
+func (u *UnitPropertiesResponse) CheckUnitHealth() (Health, string, error) {
 
 	if u.ActiveState != string(svc.Running) {
 		logrus.Infof("The ActiveState is %s, not in running state(4)", u.ActiveState)
-		return 1, fmt.Sprintf("The ActiveState is %s, not in running state(4)", u.ActiveState), nil
+		return Healthy, fmt.Sprintf("The ActiveState is %s, not in running state(4)", u.ActiveState), nil
 	}
-	return 0, "", nil
+	return Unhealthy, "", nil
 }
 
 func readJournalOutputSince(unit, sinceString string) (io.ReadCloser, error) {

--- a/api/pull.go
+++ b/api/pull.go
@@ -572,7 +572,7 @@ func pullHostStatus(host Node, respChan chan<- *httpResponse, dt *Dt, wg *sync.W
 		return
 	}
 
-	baseURL := fmt.Sprintf("http://%s:%d%s", host.IP, port, BaseRoute)
+	baseURL := fmt.Sprintf("http://%s:%d%s", host.IP, port, baseRoute)
 
 	// UnitsRoute available in router.go
 	url, err := useTLSScheme(baseURL, dt.Cfg.FlagForceTLS)

--- a/api/pull.go
+++ b/api/pull.go
@@ -626,7 +626,7 @@ func pullHostStatus(host Node, respChan chan<- *httpResponse, dt *Dt, wg *sync.W
 
 	host.Output = make(map[string]string)
 
-	// if at least one Unit is not healthy, the host should be set unhealthy
+	// if at least one Unit is not Healthy, the host should be set Unhealthy
 	for _, propertiesMap := range jsonBody.Array {
 		if propertiesMap.UnitHealth > host.Health {
 			host.Health = propertiesMap.UnitHealth

--- a/api/pull_test.go
+++ b/api/pull_test.go
@@ -18,7 +18,7 @@ func (s *PullerTestSuit) SetupTest() {
 	s.assert = assertPackage.New(s.T())
 	s.dt = &Dt{
 		DtDCOSTools: &fakeDCOSTools{},
-		Cfg:         testCfg,
+		Cfg:         testCfg(),
 		MR:          &MonitoringResponse{},
 	}
 	runPull(s.dt)

--- a/api/router.go
+++ b/api/router.go
@@ -16,8 +16,8 @@ type key int
 
 var dtKey key = 1
 
-// BaseRoute a base dcos-diagnostics endpoint location.
-const BaseRoute string = "/system/health/v1"
+// baseRoute a base dcos-diagnostics endpoint location.
+const baseRoute string = "/system/health/v1"
 
 type routeHandler struct {
 	url                 string
@@ -102,18 +102,18 @@ func getRoutes(debug bool) []routeHandler {
 	routes := []routeHandler{
 		{
 			// /system/health/v1
-			url:     BaseRoute,
+			url:     baseRoute,
 			handler: unitsHealthStatus,
 		},
 		{
 			// /system/health/v1/report
-			url:           fmt.Sprintf("%s/report", BaseRoute),
+			url:           fmt.Sprintf("%s/report", baseRoute),
 			handler:       reportHandler,
 			canFlushCache: true,
 		},
 		{
 			// /system/health/v1/report/download
-			url:     fmt.Sprintf("%s/report/download", BaseRoute),
+			url:     fmt.Sprintf("%s/report/download", baseRoute),
 			handler: reportHandler,
 			headers: []header{
 				{
@@ -125,49 +125,49 @@ func getRoutes(debug bool) []routeHandler {
 		},
 		{
 			// /system/health/v1/units
-			url:           fmt.Sprintf("%s/units", BaseRoute),
+			url:           fmt.Sprintf("%s/units", baseRoute),
 			handler:       getAllUnitsHandler,
 			canFlushCache: true,
 		},
 		{
 			// /system/health/v1/units/<unitid>
-			url:           fmt.Sprintf("%s/units/{unitid}", BaseRoute),
+			url:           fmt.Sprintf("%s/units/{unitid}", baseRoute),
 			handler:       getUnitByIDHandler,
 			canFlushCache: true,
 		},
 		{
 			// /system/health/v1/units/<unitid>/nodes
-			url:           fmt.Sprintf("%s/units/{unitid}/nodes", BaseRoute),
+			url:           fmt.Sprintf("%s/units/{unitid}/nodes", baseRoute),
 			handler:       getNodesByUnitIDHandler,
 			canFlushCache: true,
 		},
 		{
 			// /system/health/v1/units/<unitid>/nodes/<nodeid>
-			url:           fmt.Sprintf("%s/units/{unitid}/nodes/{nodeid}", BaseRoute),
+			url:           fmt.Sprintf("%s/units/{unitid}/nodes/{nodeid}", baseRoute),
 			handler:       getNodeByUnitIDNodeIDHandler,
 			canFlushCache: true,
 		},
 		{
 			// /system/health/v1/nodes
-			url:           fmt.Sprintf("%s/nodes", BaseRoute),
+			url:           fmt.Sprintf("%s/nodes", baseRoute),
 			handler:       getNodesHandler,
 			canFlushCache: true,
 		},
 		{
 			// /system/health/v1/nodes/<nodeid>
-			url:           fmt.Sprintf("%s/nodes/{nodeid}", BaseRoute),
+			url:           fmt.Sprintf("%s/nodes/{nodeid}", baseRoute),
 			handler:       getNodeByIDHandler,
 			canFlushCache: true,
 		},
 		{
 			// /system/health/v1/nodes/<nodeid>/units
-			url:           fmt.Sprintf("%s/nodes/{nodeid}/units", BaseRoute),
+			url:           fmt.Sprintf("%s/nodes/{nodeid}/units", baseRoute),
 			handler:       getNodeUnitsByNodeIDHandler,
 			canFlushCache: true,
 		},
 		{
 			// /system/health/v1/nodes/<nodeid>/units/<unitid>
-			url:           fmt.Sprintf("%s/nodes/{nodeid}/units/{unitid}", BaseRoute),
+			url:           fmt.Sprintf("%s/nodes/{nodeid}/units/{unitid}", baseRoute),
 			handler:       getNodeUnitByNodeIDUnitIDHandler,
 			canFlushCache: true,
 		},
@@ -175,12 +175,12 @@ func getRoutes(debug bool) []routeHandler {
 		// diagnostics routes
 		{
 			// /system/health/v1/logs
-			url:     BaseRoute + "/logs",
+			url:     baseRoute + "/logs",
 			handler: logsListHandler,
 		},
 		{
 			// /system/health/v1/logs/<unitid/<hours>
-			url:     BaseRoute + "/logs/{provider}/{entity}",
+			url:     baseRoute + "/logs/{provider}/{entity}",
 			handler: getUnitLogHandler,
 			headers: []header{
 				{
@@ -192,36 +192,36 @@ func getRoutes(debug bool) []routeHandler {
 		},
 		{
 			// /system/health/v1/report/diagnostics
-			url:     BaseRoute + "/report/diagnostics/create",
+			url:     baseRoute + "/report/diagnostics/create",
 			handler: createBundleHandler,
 			methods: []string{"POST"},
 		},
 		{
-			url:     BaseRoute + "/report/diagnostics/cancel",
+			url:     baseRoute + "/report/diagnostics/cancel",
 			handler: cancelBundleReportHandler,
 			methods: []string{"POST"},
 		},
 		{
-			url:     BaseRoute + "/report/diagnostics/status",
+			url:     baseRoute + "/report/diagnostics/status",
 			handler: diagnosticsJobStatusHandler,
 		},
 		{
-			url:     BaseRoute + "/report/diagnostics/status/all",
+			url:     baseRoute + "/report/diagnostics/status/all",
 			handler: diagnosticsJobStatusAllHandler,
 		},
 		{
 			// /system/health/v1/report/diagnostics/list
-			url:     BaseRoute + "/report/diagnostics/list",
+			url:     baseRoute + "/report/diagnostics/list",
 			handler: listAvailableLocalBundlesFilesHandler,
 		},
 		{
 			// /system/health/v1/report/diagnostics/list/all
-			url:     BaseRoute + "/report/diagnostics/list/all",
+			url:     baseRoute + "/report/diagnostics/list/all",
 			handler: listAvailableGLobalBundlesFilesHandler,
 		},
 		{
 			// /system/health/v1/report/diagnostics/serve/<file>
-			url:     BaseRoute + "/report/diagnostics/serve/{file}",
+			url:     baseRoute + "/report/diagnostics/serve/{file}",
 			handler: downloadBundleHandler,
 			headers: []header{
 				{
@@ -232,13 +232,13 @@ func getRoutes(debug bool) []routeHandler {
 		},
 		{
 			// /system/health/v1/report/diagnostics/delete/<file>
-			url:     BaseRoute + "/report/diagnostics/delete/{file}",
+			url:     baseRoute + "/report/diagnostics/delete/{file}",
 			handler: deleteBundleHandler,
 			methods: []string{"POST"},
 		},
 		// self test route
 		{
-			url:     BaseRoute + "/selftest/info",
+			url:     baseRoute + "/selftest/info",
 			handler: selfTestHandler,
 		},
 	}
@@ -247,7 +247,7 @@ func getRoutes(debug bool) []routeHandler {
 		logrus.Debug("Enabling pprof endpoints.")
 		routes = append(routes, []routeHandler{
 			{
-				url:     BaseRoute + "/debug/pprof/",
+				url:     baseRoute + "/debug/pprof/",
 				handler: pprof.Index,
 				gzip:    true,
 				headers: []header{
@@ -258,7 +258,7 @@ func getRoutes(debug bool) []routeHandler {
 				},
 			},
 			{
-				url:     BaseRoute + "/debug/pprof/cmdline",
+				url:     baseRoute + "/debug/pprof/cmdline",
 				handler: pprof.Cmdline,
 				gzip:    true,
 				headers: []header{
@@ -269,7 +269,7 @@ func getRoutes(debug bool) []routeHandler {
 				},
 			},
 			{
-				url:     BaseRoute + "/debug/pprof/profile",
+				url:     baseRoute + "/debug/pprof/profile",
 				handler: pprof.Profile,
 				gzip:    true,
 				headers: []header{
@@ -280,7 +280,7 @@ func getRoutes(debug bool) []routeHandler {
 				},
 			},
 			{
-				url:     BaseRoute + "/debug/pprof/symbol",
+				url:     baseRoute + "/debug/pprof/symbol",
 				handler: pprof.Symbol,
 				gzip:    true,
 				headers: []header{
@@ -291,7 +291,7 @@ func getRoutes(debug bool) []routeHandler {
 				},
 			},
 			{
-				url:     BaseRoute + "/debug/pprof/trace",
+				url:     baseRoute + "/debug/pprof/trace",
 				handler: pprof.Trace,
 				gzip:    true,
 				headers: []header{
@@ -302,7 +302,7 @@ func getRoutes(debug bool) []routeHandler {
 				},
 			},
 			{
-				url: BaseRoute + "/debug/pprof/{profile}",
+				url: baseRoute + "/debug/pprof/{profile}",
 				handler: func(w http.ResponseWriter, req *http.Request) {
 					profile := mux.Vars(req)["profile"]
 					pprof.Handler(profile).ServeHTTP(w, req)

--- a/api/structures.go
+++ b/api/structures.go
@@ -16,11 +16,21 @@ type MonitoringResponse struct {
 	UpdatedTime time.Time
 }
 
+// Health is a type to indicates health of the unit.
+type Health int
+
+const (
+	// Unhealthy indicates Unit is not healthy
+	Unhealthy = 0
+	// Healthy indicates Unit is healthy
+	Healthy = 1
+)
+
 // Unit for stands for systemd unit.
 type Unit struct {
 	UnitName   string
 	Nodes      []Node `json:",omitempty"`
-	Health     int
+	Health     Health
 	Title      string
 	Timestamp  time.Time
 	PrettyName string
@@ -32,7 +42,7 @@ type Node struct {
 	Role    string
 	IP      string
 	Host    string
-	Health  int
+	Health  Health
 	Output  map[string]string
 	Units   []Unit `json:",omitempty"`
 	MesosID string
@@ -59,7 +69,7 @@ type UnitsHealthResponseJSONStruct struct {
 // HealthResponseValues is a health values json response.
 type HealthResponseValues struct {
 	UnitID     string `json:"id"`
-	UnitHealth int    `json:"health"`
+	UnitHealth Health `json:"health"`
 	UnitOutput string `json:"output"`
 	UnitTitle  string `json:"description"`
 	Help       string `json:"help"`
@@ -75,7 +85,7 @@ type UnitsResponseJSONStruct struct {
 type UnitResponseFieldsStruct struct {
 	UnitID     string `json:"id"`
 	PrettyName string `json:"name"`
-	UnitHealth int    `json:"health"`
+	UnitHealth Health `json:"health"`
 	UnitTitle  string `json:"description"`
 }
 
@@ -87,14 +97,14 @@ type NodesResponseJSONStruct struct {
 // NodeResponseFieldsStruct contains a response from a node.
 type NodeResponseFieldsStruct struct {
 	HostIP     string `json:"host_ip"`
-	NodeHealth int    `json:"health"`
+	NodeHealth Health `json:"health"`
 	NodeRole   string `json:"role"`
 }
 
 // NodeResponseFieldsWithErrorStruct contains node response with errors.
 type NodeResponseFieldsWithErrorStruct struct {
 	HostIP     string `json:"host_ip"`
-	NodeHealth int    `json:"health"`
+	NodeHealth Health `json:"health"`
 	NodeRole   string `json:"role"`
 	UnitOutput string `json:"output"`
 	Help       string `json:"help"`

--- a/api/structures_test.go
+++ b/api/structures_test.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"testing"
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+)
+
+// this test is created to check if aliased types properly serialize to JSON
+func TestUnitSerialization(t *testing.T) {
+	t.Parallel()
+
+	given := `{
+ "UnitName": "test name",
+ "Health": 1,
+ "Title": "test title",
+ "Timestamp": "0001-01-01T00:00:00Z",
+ "PrettyName": "this is very pretty name"
+}`
+
+	expected := Unit{
+		UnitName: "test name",
+		Health: 1,
+		Title: "test title",
+		PrettyName: "this is very pretty name",
+	}
+	var actual Unit
+	err := json.Unmarshal([]byte(given), &actual)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+
+	raw, err := json.MarshalIndent(expected, "", " ")
+	assert.NoError(t, err)
+	assert.Equal(t, given, string(raw))
+
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,8 +26,8 @@ function logmsg {
 }
 
 function _gometalinter {
-    logmsg "Disable 'gometaliner' until https://github.com/alecthomas/gometalinter/issues/521"
-    #gometalinter ./...  --config=.gometalinter.json
+    logmsg "Running 'gometaliner' ..."
+    gometalinter ./...  --config=.gometalinter.json
 }
 
 function _unittest_with_coverage {


### PR DESCRIPTION
Currently primitive types are used for any domain objecst
in the system. This change intorduce Health type which is
aliased `int`. See: [PrimitiveObsession](http://wiki.c2.com/?PrimitiveObsession)

There is no need ot expose base route outside of the package.

This structure is implemented in different place.
There is no need to keep it.
