### PR TITLE
Add `dep check` to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ script: go build
 
 jobs:
   include:
+  - name: "Dep"
+    script: go get -u github.com/golang/dep/cmd/dep && dep check
   - name: "Linter"            # names the first Tests stage job
     script: go get -u github.com/alecthomas/gometalinter && gometalinter --install && gometalinter ./... --config .gometalinter.json
   - name: "Tests"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -338,6 +338,7 @@
     "github.com/spf13/cobra",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
     "github.com/stretchr/testify/suite",
     "golang.org/x/sys/windows/svc",
     "golang.org/x/sys/windows/svc/mgr",


### PR DESCRIPTION
> dep check is a read-only command that verifies dep's sync invariants
> are met. It's primarily intended for automated use (e.g. CI or git
> pre-commit hooks). We may expand it later to include more comprehensive
> checks. https://github.com/golang/dep/commit/3201ef6a3442d3167cd54fdae5b31b039caf08bf