### PR TITLE
Search for bundles locally first

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -673,6 +673,7 @@ func listAllBundles(cfg *config.Config, DCOSTools DCOSHelper) (map[string][]bund
 func (j *DiagnosticsJob) isBundleAvailable(bundleName string) (string, string, bool, error) {
 	logrus.WithField("Bundle", bundleName).Infof("Trying to find a bundle locally")
 	localBundles, err := j.findLocalBundle()
+	logrus.WithField("localBundles", localBundles).Info("Get list of local bundles")
 	if err == nil {
 		for _, bundle := range localBundles {
 			if path.Base(bundle) == bundleName {

--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -671,6 +671,17 @@ func listAllBundles(cfg *config.Config, DCOSTools DCOSHelper) (map[string][]bund
 
 // check if a bundle is available on a cluster.
 func (j *DiagnosticsJob) isBundleAvailable(bundleName string) (string, string, bool, error) {
+	logrus.WithField("Bundle", bundleName).Infof("Trying to find a bundle locally")
+	localBundles, err := j.findLocalBundle()
+	if err == nil {
+		for _, bundle := range localBundles {
+			if path.Base(bundle) == bundleName {
+				return "", "", true, nil
+			}
+		}
+	}
+	logrus.WithField("Bundle", bundleName).WithError(err).Info("Not found bundle locally")
+
 	bundles, err := listAllBundles(j.Cfg, j.DCOSTools)
 	if err != nil {
 		return "", "", false, err

--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -182,14 +182,31 @@ func TestIsSnapshotAvailable(t *testing.T) {
 
 	tools.makeMockedResponse(url, []byte(mockedResponse), http.StatusOK, nil)
 
-	// should find
+	validFilePath := filepath.Join(cfg.FlagDiagnosticsBundleDir, "bundle-local.zip")
+	_, err := os.Create(validFilePath)
+	require.NoError(t, err)
+	invalidFilePath := filepath.Join(cfg.FlagDiagnosticsBundleDir, "local-bundle.zip")
+	_, err = os.Create(invalidFilePath)
+	require.NoError(t, err)
+
 	host, remoteSnapshot, ok, err := dt.DtDiagnosticsJob.isBundleAvailable("bundle-2016-05-13T22:11:36.zip")
 	require.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, host, "127.0.0.1")
 	assert.Equal(t, remoteSnapshot, "/system/health/v1/report/diagnostics/serve/bundle-2016-05-13T22:11:36.zip")
 
-	// should not find
+	host, remoteSnapshot, ok, err = dt.DtDiagnosticsJob.isBundleAvailable("bundle-local.zip")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Empty(t, host)
+	assert.Empty(t, remoteSnapshot)
+
+	host, remoteSnapshot, ok, err = dt.DtDiagnosticsJob.isBundleAvailable("local-bundle.zip")
+	require.NoError(t, err)
+	assert.False(t, ok, "bundles must mach bundle-*.zip pattern")
+	assert.Empty(t, host)
+	assert.Empty(t, remoteSnapshot)
+
 	host, remoteSnapshot, ok, err = dt.DtDiagnosticsJob.isBundleAvailable("bundle-123.zip")
 	assert.False(t, ok)
 	assert.Empty(t, host)


### PR DESCRIPTION
Try to find bundles locally before asking exhibitor. This is microoptimisation that is required by changes allowing any node to create its local bundle and serve it.