### PR TITLE
Fail when no external log providers config files

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -405,13 +405,13 @@ func logsListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	endspoints, err := dt.DtDiagnosticsJob.getLogsEndpoints()
+	endpoints, err := dt.DtDiagnosticsJob.getLogsEndpoints()
 	if err != nil {
 		response, _ := prepareResponseWithErr(http.StatusServiceUnavailable, err)
 		writeResponse(w, response)
 		return
 	}
-	if err := json.NewEncoder(w).Encode(endspoints); err != nil {
+	if err := json.NewEncoder(w).Encode(endpoints); err != nil {
 		log.Errorf("Failed to encode responses to json: %s", err)
 	}
 }


### PR DESCRIPTION
Current implementation silently goes over errors with reading `endpoint-config`. This commit changes this behaviour to fail when external config could not be loaded. No matter if the file is empty, does not exist or is invalid JSON.

Fixes: [DCOS_OSS-4130](https://jira.mesosphere.com/browse/DCOS_OSS-4130)