### PR TITLE
Fix golint import path

### DIFF
--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -78,7 +78,7 @@ function _goimports()
 function _golint()
 {
     logmsg("Running 'golint' ...")
-    & go get -u github.com/golang/lint/golint
+    & go get -u golang.org/x/lint/golint
     fastfail("failed to get golint")
 
     $text = & golint -set_exit_status  $PACKAGES


### PR DESCRIPTION
The following error occurs when running diagnostics tests:
*** Running 'golint' ... ***
package github.com/golang/lint/golint: code in directory D:\DCOS\diagnostics\src\github.com\golang\lint\golint expects import "golang.org/x/lint/golint"

Introduced with:
https://github.com/golang/lint/commit/9a272034dedb2a3ed05231d5604ce17fb40f0e58