### PR TITLE
Fix TestUseTLSScheme test

### DIFF
--- a/util/util_test.go
+++ b/util/util_test.go
@@ -46,7 +46,7 @@ func TestUseTLSScheme(t *testing.T) {
 
 	url, err = UseTLSScheme("", true)
 	assert.NoError(t, err)
-	assert.Equal(t, "https:", url)
+	assert.Equal(t, "https://", url)
 
 	url, err = UseTLSScheme("/http://", false)
 	assert.NoError(t, err)


### PR DESCRIPTION
The TestUseTLSScheme diagnostics test is failing with the following error:
```
=== RUN   TestUseTLSScheme --- FAIL:
 TestUseTLSScheme (0.00s)    <autogenerated>:1:
Error Trace:    util_test.go:49 
Error:          Not equal:                                      expected: "https:"                                      actual  : "https://"                                                                            Diff:                                   --- Expected                                    +++ Actual                                     
 @@ -1 +1 @@                    -https:                                         +https://                       
Test:           TestUseTLSScheme FAIL coverage: 61.5% of statements FAIL        
github.com/dcos/dcos-diagnostics/util   0.159s ***
Failed to run dcos-diagnostics unit tests
```