### PR TITLE
`UseTLSScheme` returns error when URL is empty

### DIFF
--- a/util/util_test.go
+++ b/util/util_test.go
@@ -41,12 +41,12 @@ func TestIsInList(t *testing.T) {
 
 func TestUseTLSScheme(t *testing.T) {
 	url, err := UseTLSScheme("", false)
-	assert.NoError(t, err)
-	assert.Equal(t, "", url)
+	assert.EqualError(t, err, "empty URL")
+	assert.Empty(t, "", url)
 
 	url, err = UseTLSScheme("", true)
-	assert.NoError(t, err)
-	assert.Equal(t, "https:", url)
+	assert.EqualError(t, err, "empty URL")
+	assert.Empty(t, "", url)
 
 	url, err = UseTLSScheme("/http://", false)
 	assert.NoError(t, err)

--- a/util/utils.go
+++ b/util/utils.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"net/http"
 	netUrl "net/url"
 	"strings"
@@ -10,6 +11,9 @@ import (
 
 // UseTLSScheme returns url with https scheme if use is true
 func UseTLSScheme(url string, use bool) (string, error) {
+	if url == "" {
+		return "", fmt.Errorf("empty URL")
+	}
 	if use {
 		urlObject, err := netUrl.Parse(url)
 		if err != nil {


### PR DESCRIPTION
This is a fix for problems with building dcos-diagnostics on Windows.

See: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-diagnostics-windows/127/console
Refs: #68