### PR TITLE
Log requests with LoggingHandler

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -316,7 +316,7 @@ func wrapHandler(handler http.Handler, route routeHandler, dt *Dt) http.Handler 
 		h = noCacheMiddleware(h, dt)
 	}
 
-	return h
+	return handlers.LoggingHandler(logrus.StandardLogger().Out, h)
 }
 
 func loadRoutes(router *mux.Router, dt *Dt) *mux.Router {


### PR DESCRIPTION
Requests will be logged in the following format:

```
Oct 30 22:56:41 dcos-e2e-39d6141e-c2f7-4c11-b599-d420d86b179b-master-0 dcos-diagnostics[14814]: 172.17.0.2 - - [30/Oct/2018:22:56:41 +0000] "GET /system/health/v1 HTTP/1.1" 200 4740
```

See: https://godoc.org/github.com/gorilla/handlers#LoggingHandler
Related: https://github.com/gorilla/mux/issues/416