### PR TITLE
Do NOT make remote call for local status

### DIFF
--- a/api/mock_tools_test.go
+++ b/api/mock_tools_test.go
@@ -1,12 +1,13 @@
 package api
 
 import (
+	"time"
+
 	"github.com/dcos/dcos-diagnostics/dcos"
 	"github.com/stretchr/testify/mock"
-	"time"
 )
 
-type MockedTools struct{
+type MockedTools struct {
 	mock.Mock
 }
 


### PR DESCRIPTION
Currently to get status we query all nodes including local one.
This change try to get local status using local object.