### PR TITLE
Updating expected results to include carriage return when run on windows

### DIFF
--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -140,7 +140,7 @@ func TestDispatchLogsForCommand(t *testing.T) {
 
 	data, err := ioutil.ReadAll(r)
 	require.NoError(t, err)
-        var expected_result string
+        var expectedResult string
         expectedResult = "OK\n"
         if runtime.GOOS == "windows" {
            expectedResult = "OK\r\n"

--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -141,11 +141,11 @@ func TestDispatchLogsForCommand(t *testing.T) {
 	data, err := ioutil.ReadAll(r)
 	require.NoError(t, err)
         var expected_result string
-        expected_result = "OK\n"
+        expectedResult = "OK\n"
         if runtime.GOOS == "windows" {
-           expected_result = "OK\r\n"
+           expectedResult = "OK\r\n"
         }
-	assert.Equal(t, expected_result, string(data))
+	assert.Equal(t, expectedResult, string(data))
 }
 
 func TestDispatchLogsForFiles(t *testing.T) {

--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -140,7 +140,12 @@ func TestDispatchLogsForCommand(t *testing.T) {
 
 	data, err := ioutil.ReadAll(r)
 	require.NoError(t, err)
-	assert.Equal(t, "OK\r\n", string(data))
+        var expected_result string
+        expected_result = "OK\n"
+        if runtime.GOOS == "windows" {
+           expected_result = "OK\r\n"
+        }
+	assert.Equal(t, expected_result, string(data))
 }
 
 func TestDispatchLogsForFiles(t *testing.T) {

--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -140,7 +140,7 @@ func TestDispatchLogsForCommand(t *testing.T) {
 
 	data, err := ioutil.ReadAll(r)
 	require.NoError(t, err)
-	assert.Equal(t, "OK\n", string(data))
+	assert.Equal(t, "OK\r\n", string(data))
 }
 
 func TestDispatchLogsForFiles(t *testing.T) {


### PR DESCRIPTION
Attempting to update tests to pass after rebuilding our windows 10 agents.
Test is current failing due to expected results not including the '\r' character.
Am open to alternatives if someone can suggest a means to configure win10 to not produce '\r' characters in output.