### PR TITLE
Fix compilation on Darwin by adding noop stubs of interfaces

### DIFF
--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -164,7 +164,7 @@ func TestDispatchLogsForFiles(t *testing.T) {
 }
 
 func TestDispatchLogsForUnit(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		t.Skip()
 	}
 

--- a/api/health_darwin.go
+++ b/api/health_darwin.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/dcos/dcos-diagnostics/dcos"
+)
+
+// SystemdUnits used to make GetUnitsProperties thread safe.
+type SystemdUnits struct {
+	sync.Mutex
+}
+
+// GetUnits returns an error on darwin because it's not supported
+func (s *SystemdUnits) GetUnits(tools dcos.Tooler) (allUnits []HealthResponseValues, err error) {
+	return nil, errors.New("does not work on darwin")
+}
+
+// GetUnitsProperties returns an error on darwin because it's not supported
+func (s *SystemdUnits) GetUnitsProperties(tools dcos.Tooler) (healthReport UnitsHealthResponseJSONStruct, err error) {
+	var emptyReport UnitsHealthResponseJSONStruct
+	return emptyReport, errors.New("does not work on darwin")
+}

--- a/api/properties_darwin.go
+++ b/api/properties_darwin.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"errors"
+
+	"github.com/dcos/dcos-diagnostics/dcos"
+)
+
+// CheckUnitHealth returns an error on darwin because it's not supported
+func (u *UnitPropertiesResponse) CheckUnitHealth() (dcos.Health, string, error) {
+	return dcos.Unhealthy, "", errors.New("does not work on darwin")
+}

--- a/cmd/listener_darwin.go
+++ b/cmd/listener_darwin.go
@@ -1,0 +1,23 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net"
+)
+
+func getListener(unsetEnv bool) ([]net.Listener, error) {
+	return nil, nil
+}

--- a/dcos/tools_darwin.go
+++ b/dcos/tools_darwin.go
@@ -1,0 +1,44 @@
+package dcos
+
+import (
+	"errors"
+	"net/http"
+	"sync"
+
+	"github.com/dcos/dcos-go/dcos/nodeutil"
+)
+
+// Tools is implementation of dcos.Tooler interface.
+type Tools struct {
+	sync.Mutex
+
+	ExhibitorURL string
+	Role         string
+	ForceTLS     bool
+	NodeInfo     nodeutil.NodeInfo
+	Transport    http.RoundTripper
+
+	hostname string
+	ip       string
+	mesosID  string
+}
+
+func (st *Tools) InitializeUnitControllerConnection() (err error) {
+	return errors.New("does not work on darwin")
+}
+
+func (st *Tools) CloseUnitControllerConnection() error {
+	return errors.New("does not work on darwin")
+}
+
+func (st *Tools) GetUnitProperties(pname string) (map[string]interface{}, error) {
+	return nil, errors.New("does not work on darwin")
+}
+
+func (st *Tools) GetUnitNames() (units []string, err error) {
+	return nil, errors.New("does not work on darwin")
+}
+
+func (st *Tools) GetJournalOutput(unit string) (string, error) {
+	return "", errors.New("does not work on darwin")
+}

--- a/units/helpers_darwin.go
+++ b/units/helpers_darwin.go
@@ -1,0 +1,11 @@
+package units
+
+import (
+	"errors"
+	"io"
+)
+
+// ReadJournalOutputSince returns error since darwin does not support journal
+func ReadJournalOutputSince(unit, sinceString string) (io.ReadCloser, error) {
+	return nil, errors.New("does not work on darwin")
+}


### PR DESCRIPTION
This adds the necessary noop functions to allow compilation on Darwin, which makes it possible to run tests/linters/etc.

When possible I tried to copy the behaviour of the Windows-implementations and where not I opted to return an error to signal that it's an unsupported feature.

I'm still unsure about the comments, opinions welcome 😄 