### PR TITLE
Fix test to works on Windows

### DIFF
--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -144,7 +144,7 @@ func TestDispatchLogsForCommand(t *testing.T) {
 
 	data, err := ioutil.ReadAll(r)
 	require.NoError(t, err)
-	assert.Equal(t, "OK\n", string(data))
+	assert.Contains(t, string(data), "OK")
 }
 
 func TestDispatchLogsForFiles(t *testing.T) {


### PR DESCRIPTION
Windows uses `/r/n` for new line. Our test expect only `/n` this commit
changes assertion to check only for expected text without new line.

Fixes: DCOS-47009
Refs: https://github.com/dcos/dcos-diagnostics/pull/81