### PR TITLE
Fix err shadows

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -232,7 +232,7 @@ func (j *DiagnosticsJob) runBackgroundJob(ctx context.Context, nodes []dcos.Node
 	j.setJobProgressPercentage(100)
 
 	for _, path := range zips {
-		if err := appendToZip(zipWriter, path); err != nil {
+		if err = appendToZip(zipWriter, path); err != nil {
 			j.logError(err, "Could not create a bundle", summaryErrorsReport)
 		}
 		if err = os.Remove(path); err != nil {


### PR DESCRIPTION
> api/diagnostics.go:235::warning: declaration of "err" shadows declaration at api/diagnostics.go:206 (vetshadow)

Refs: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-diagnostics/job/dcos-diagnostics-pulls/296/console