### PR TITLE
Enable optional files in diagnsotics-bundle

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -957,7 +958,12 @@ func (j *DiagnosticsJob) dispatchLogs(ctx context.Context, provider, entity stri
 			return r, errors.New("Not allowed to read a file")
 		}
 		logrus.Debugf("Found a file %s", fileProvider.Location)
-		return os.Open(fileProvider.Location)
+
+		file, err := os.Open(fileProvider.Location)
+		if err != nil && fileProvider.Optional {
+			return ioutil.NopCloser(bytes.NewReader([]byte(err.Error()))), nil
+		}
+		return file, err
 	}
 	if provider == "cmds" {
 		logrus.Debugf("dispatching a command %s", entity)

--- a/api/providers.go
+++ b/api/providers.go
@@ -28,6 +28,7 @@ type HTTPProvider struct {
 type FileProvider struct {
 	Location string
 	Role     []string
+	Optional bool
 }
 
 // CommandProvider is a local command to execute.

--- a/api/testdata/endpoint-config.json
+++ b/api/testdata/endpoint-config.json
@@ -49,7 +49,8 @@
       "Role": ["master"]
     },
     {
-      "Location": "/etc/resolv.conf"
+      "Location": "/not/existing/file",
+      "Optional": true
     }
   ],
   "LocalCommands": [
@@ -71,6 +72,10 @@
     },
     {
       "Command": ["echo", "OK"]
+    },
+    {
+      "Command": ["does", "not", "exist"],
+      "Optional": true
     }
   ]
 }

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -3,14 +3,15 @@ package fetcher
 import (
 	"archive/zip"
 	"context"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/dcos/dcos-diagnostics/dcos"
 	"github.com/stretchr/testify/assert"
@@ -20,8 +21,6 @@ import (
 func Test_NewReturnErrorWhenCantCreateZip(t *testing.T) {
 	_, err := New("not_existing_dir", nil, nil, nil, nil)
 	assert.Contains(t, err.Error(), "could not create temp zip file in not_existing_dir")
-
-
 
 	assert.NoError(t, testutil.CollectAndCompare(fetchHistogram, strings.NewReader("")))
 }


### PR DESCRIPTION
Introduce `Optional` option in endpoint configuration for files. If a file is marked as optional then errors are swallowed and do not affect bundle creation process. Error is included as file content. This will allow us to gather files that are not always available on cluster such as rotated log files or configuration files for optional components.

Fixes: https://jira.mesosphere.com/browse/DCOS_OSS-4949