### PR TITLE
Add option to skip running builds in Docker

### DIFF
--- a/api/properties.go
+++ b/api/properties.go
@@ -1,13 +1,5 @@
 package api
 
-import (
-	"strings"
-
-	"github.com/dcos/dcos-diagnostics/dcos"
-	"github.com/mitchellh/mapstructure"
-	"github.com/sirupsen/logrus"
-)
-
 // UnitPropertiesResponse is a structure to unmarshal dbus.GetunitProperties response
 type UnitPropertiesResponse struct {
 	ID             string `mapstructure:"Id"`
@@ -21,47 +13,4 @@ type UnitPropertiesResponse struct {
 	ActiveEnterTimestampMonotonic   uint64
 	ActiveExitTimestampMonotonic    uint64
 	InactiveEnterTimestampMonotonic uint64
-}
-
-func normalizeProperty(unitProps map[string]interface{}, tools dcos.Tooler) (HealthResponseValues, error) {
-	var (
-		description, prettyName string
-		propsResponse           UnitPropertiesResponse
-	)
-
-	if err := mapstructure.Decode(unitProps, &propsResponse); err != nil {
-		return HealthResponseValues{}, err
-	}
-
-	unitHealth, unitOutput, err := propsResponse.CheckUnitHealth()
-	if err != nil {
-		return HealthResponseValues{}, err
-	}
-
-	if unitHealth > 0 {
-		journalOutput, err := tools.GetJournalOutput(propsResponse.ID)
-		if err == nil {
-			unitOutput += "\n"
-			unitOutput += journalOutput
-		} else {
-			logrus.Errorf("Could not read journalctl: %s", err)
-		}
-	}
-
-	s := strings.Split(propsResponse.Description, ": ")
-	if len(s) != 2 {
-		description = strings.Join(s, " ")
-
-	} else {
-		prettyName, description = s[0], s[1]
-	}
-
-	return HealthResponseValues{
-		UnitID:     propsResponse.ID,
-		UnitHealth: unitHealth,
-		UnitOutput: unitOutput,
-		UnitTitle:  description,
-		Help:       "",
-		PrettyName: prettyName,
-	}, nil
 }

--- a/api/properties_util.go
+++ b/api/properties_util.go
@@ -1,0 +1,54 @@
+// +build linux windows
+
+package api
+
+import (
+	"strings"
+
+	"github.com/dcos/dcos-diagnostics/dcos"
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+)
+
+func normalizeProperty(unitProps map[string]interface{}, tools dcos.Tooler) (HealthResponseValues, error) {
+	var (
+		description, prettyName string
+		propsResponse           UnitPropertiesResponse
+	)
+
+	if err := mapstructure.Decode(unitProps, &propsResponse); err != nil {
+		return HealthResponseValues{}, err
+	}
+
+	unitHealth, unitOutput, err := propsResponse.CheckUnitHealth()
+	if err != nil {
+		return HealthResponseValues{}, err
+	}
+
+	if unitHealth > 0 {
+		journalOutput, err := tools.GetJournalOutput(propsResponse.ID)
+		if err == nil {
+			unitOutput += "\n"
+			unitOutput += journalOutput
+		} else {
+			logrus.Errorf("Could not read journalctl: %s", err)
+		}
+	}
+
+	s := strings.Split(propsResponse.Description, ": ")
+	if len(s) != 2 {
+		description = strings.Join(s, " ")
+
+	} else {
+		prettyName, description = s[0], s[1]
+	}
+
+	return HealthResponseValues{
+		UnitID:     propsResponse.ID,
+		UnitHealth: unitHealth,
+		UnitOutput: unitOutput,
+		UnitTitle:  description,
+		Help:       "",
+		PrettyName: prettyName,
+	}, nil
+}

--- a/dcos/tools_darwin.go
+++ b/dcos/tools_darwin.go
@@ -19,8 +19,6 @@ type Tools struct {
 	Transport    http.RoundTripper
 
 	hostname string
-	ip       string
-	mesosID  string
 }
 
 func (st *Tools) InitializeUnitControllerConnection() (err error) {


### PR DESCRIPTION
By setting the envvar `NO_DOCKER` make will not run the given target
in a Docker container. This way builds are much faster because no
Docker image is built and no container has to be started.

On macOS `deadcode` complained about an unused function so that I had
to move that function into a file of its own and add build tags to it
so that it isn't compiled on macOS.

Also I removed some unused struct fields in macOS-specific code.

Fixes https://jira.mesosphere.com/browse/DCOS_OSS-5007