### PR TITLE
Allow optional commands

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -27,7 +28,6 @@ import (
 	"github.com/dcos/dcos-diagnostics/units"
 	"github.com/dcos/dcos-diagnostics/util"
 
-	"github.com/dcos/dcos-go/exec"
 	"github.com/shirou/gopsutil/disk"
 	"github.com/sirupsen/logrus"
 )
@@ -996,16 +996,14 @@ func (j *DiagnosticsJob) dispatchLogs(ctx context.Context, provider, entity stri
 		if !canExecute {
 			return r, errors.New("Not allowed to execute a command")
 		}
-		var args []string
-		if len(cmdProvider.Command) > 1 {
-			args = cmdProvider.Command[1:]
+
+		cmd := exec.CommandContext(ctx, cmdProvider.Command[0], cmdProvider.Command[1:]...)
+		output, err := cmd.CombinedOutput()
+		if err != nil && cmdProvider.Optional {
+			return ioutil.NopCloser(bytes.NewReader([]byte(err.Error()))), nil
 		}
 
-		ce, err := exec.Run(ctx, cmdProvider.Command[0], args)
-		if err != nil {
-			return nil, err
-		}
-		return &execCloser{ce}, nil
+		return ioutil.NopCloser(bytes.NewReader(output)), err
 	}
 	return r, errors.New("Unknown provider " + provider)
 }
@@ -1013,17 +1011,4 @@ func (j *DiagnosticsJob) dispatchLogs(ctx context.Context, provider, entity stri
 // the summary report is a file added to a zip bundle file to track any errors occurred during collection logs.
 func updateSummaryReportBuffer(prefix string, err string, r *bytes.Buffer) {
 	r.WriteString(fmt.Sprintf("%s [%s] %s \n", time.Now().String(), prefix, err))
-}
-
-// implement a io.ReadCloser wrapper over dcos/exec
-type execCloser struct {
-	r io.Reader
-}
-
-func (e *execCloser) Read(b []byte) (int, error) {
-	return e.r.Read(b)
-}
-
-func (e *execCloser) Close() error {
-	return nil
 }

--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -1000,7 +1000,9 @@ func (j *DiagnosticsJob) dispatchLogs(ctx context.Context, provider, entity stri
 		cmd := exec.CommandContext(ctx, cmdProvider.Command[0], cmdProvider.Command[1:]...)
 		output, err := cmd.CombinedOutput()
 		if err != nil && cmdProvider.Optional {
-			return ioutil.NopCloser(bytes.NewReader([]byte(err.Error()))), nil
+			// combine output with error
+			o := append([]byte(err.Error()+"\n"), output...)
+			return ioutil.NopCloser(bytes.NewReader(o)), nil
 		}
 
 		return ioutil.NopCloser(bytes.NewReader(output)), err

--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -97,7 +97,8 @@ func TestDiagnosticsJobInitWithValidFilesCheckIfConfigsAreMerged(t *testing.T) {
 		},
 		"ps_aux_ww_Z.output":                {Command: []string{"ps", "aux", "ww", "Z"}},
 		"systemctl_list-units_dcos*.output": {Command: []string{"systemctl", "list-units", "dcos*"}},
-		"does_not_exist.output":             {Command: []string{"does", "not", "exist"}},
+		"does_not_exist.output":             {Command: []string{"does", "not", "exist"}, Optional: true},
+		"does_not_exist_required.output":    {Command: []string{"does", "not", "exist", "required"}, Optional: false},
 	}, job.logProviders.LocalCommands)
 
 }
@@ -166,6 +167,7 @@ func TestGetLogsEndpoints(t *testing.T) {
 			x[k] = endpointSpec{PortAndPath: v}
 		}
 		x["uri_not_avail.txt"] = endpointSpec{PortAndPath: ":5050/storage/uri_not_avail", Optional: true}
+		x["does_not_exist_required.output"] = endpointSpec{PortAndPath: logPath + "cmds/does_not_exist_required.output"}
 		return
 	}(), "only endpoints for master role should appear here")
 }
@@ -185,7 +187,7 @@ func TestDispatchLogsForCommand(t *testing.T) {
 	assert.Equal(t, "OK\n", string(data))
 }
 
-func TestDispatchLogsForCommandThatNotExists(t *testing.T) {
+func TestDispatchLogsForCommandThatNotExistsButIsOptional(t *testing.T) {
 	job := DiagnosticsJob{Cfg: testCfg(), DCOSTools: &fakeDCOSTools{}}
 	job.Cfg.FlagDiagnosticsBundleEndpointsConfigFiles = []string{filepath.Join("testdata", "endpoint-config-2.json")}
 
@@ -193,11 +195,22 @@ func TestDispatchLogsForCommandThatNotExists(t *testing.T) {
 	require.NoError(t, err)
 
 	r, err := job.dispatchLogs(context.TODO(), "cmds", "does_not_exist.output")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	data, err := ioutil.ReadAll(r)
 	require.NoError(t, err)
-	assert.Empty(t, data)
+	assert.Contains(t, string(data), `exec: "does": executable file not found in `)
+}
+
+func TestDispatchLogsForCommandThatNotExistsAndIsRequired(t *testing.T) {
+	job := DiagnosticsJob{Cfg: testCfg(), DCOSTools: &fakeDCOSTools{}}
+	job.Cfg.FlagDiagnosticsBundleEndpointsConfigFiles = []string{filepath.Join("testdata", "endpoint-config.json")}
+
+	err := job.Init()
+	require.NoError(t, err)
+
+	_, err = job.dispatchLogs(context.TODO(), "cmds", "does_not_exist_required.output")
+	assert.Error(t, err)
 }
 
 func TestDispatchLogsForFiles(t *testing.T) {

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -332,6 +332,7 @@ func (h *handler) getUnitLogHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		response, _ := prepareResponseWithErr(http.StatusServiceUnavailable, err)
 		writeResponse(w, response)
+		log.WithError(err).Warnf("Could NOT prepare a response for %s", r.URL.Path)
 		return
 	}
 	defer unitLogOut.Close()

--- a/api/providers.go
+++ b/api/providers.go
@@ -34,8 +34,9 @@ type FileProvider struct {
 
 // CommandProvider is a local command to execute.
 type CommandProvider struct {
-	Command []string
-	Role    []string
+	Command  []string
+	Role     []string
+	Optional bool
 }
 
 func loadProviders(cfg *config.Config, DCOSTools dcos.Tooler) (*LogProviders, error) {

--- a/api/testdata/endpoint-config-2.json
+++ b/api/testdata/endpoint-config-2.json
@@ -16,6 +16,10 @@
     {
       "Command": ["does", "not", "exist"],
       "Optional": true
+    },
+    {
+      "Command": ["does", "not", "exist", "required"],
+      "Optional": false
     }
   ]
 }

--- a/api/testdata/endpoint-config.json
+++ b/api/testdata/endpoint-config.json
@@ -49,6 +49,10 @@
     {
       "Location": "/var/lib/dcos/exhibitor/conf/zoo.cfg",
       "Role": ["master"]
+    },
+    {
+      "Location": "/not/existing/file",
+      "Optional": true
     }
   ],
   "LocalCommands": [
@@ -70,6 +74,10 @@
     },
     {
       "Command": ["echo", "OK"]
+    },
+    {
+      "Command": ["does", "not", "exist"],
+      "Optional": true
     }
   ]
 }


### PR DESCRIPTION
Currently if command does not exists we create empty file. This change includes `stderr` in command output file and if command does not exists or error (returns non `0` result) then mark it as failed and note it in `summarryErrorReport.txt`. This change introduce also `Optional` field for command so event if they fail, the bundle could be finished whiteout errors just like files.

Fixes: DCOS_OSS-5026
Refs: https://github.com/dcos/dcos-diagnostics/pull/94