### PR TITLE
Optional http endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ ifdef NO_DOCKER
 else
   define inDocker
     docker run \
+      $(shell test -t 0 && echo "-t -i" || true) \
       -v $(CURRENT_DIR):$(PKG_DIR) \
       -w $(PKG_DIR) \
       --rm \

--- a/api/providers.go
+++ b/api/providers.go
@@ -22,6 +22,7 @@ type HTTPProvider struct {
 	URI      string
 	FileName string
 	Role     []string
+	Optional bool
 }
 
 // FileProvider is a local file provider.

--- a/api/testdata/endpoint-config.json
+++ b/api/testdata/endpoint-config.json
@@ -17,6 +17,13 @@
     },
     {
       "Port": 5050,
+      "Uri": "/storage/uri_not_avail",
+      "Role": ["master"],
+      "Optional": true,
+      "FileName": "uri_not_avail.txt"
+    },
+    {
+      "Port": 5050,
       "Uri": "/system/stats.json",
       "Role": ["master"]
     },

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -31,6 +31,7 @@ type EndpointRequest struct {
 	URL      string
 	Node     dcos.Node
 	FileName string
+	Optional bool
 }
 
 // StatusUpdate is an update message published by Fetcher when EndpointRequest is done. If error occurred	 during
@@ -122,7 +123,11 @@ func getDataToZip(ctx context.Context, client *http.Client, r EndpointRequest, z
 
 	resp, err := get(ctx, client, r.URL)
 	if err != nil {
-		return fmt.Errorf("could not get from url %s: %s", r.URL, err)
+		if !r.Optional {
+			return fmt.Errorf("could not get from url %s: %s", r.URL, err)
+		}
+		logrus.Infof("Failed to fetch OPTIONAL URL %s: %v", r.URL, err)
+		return nil
 	}
 
 	duration := time.Since(start)

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -126,7 +126,7 @@ func getDataToZip(ctx context.Context, client *http.Client, r EndpointRequest, z
 		if !r.Optional {
 			return fmt.Errorf("could not get from url %s: %s", r.URL, err)
 		}
-		logrus.Infof("Failed to fetch OPTIONAL URL %s: %v", r.URL, err)
+		logrus.WithError(err).Infof("Failed to fetch OPTIONAL URL %s", r.URL)
 		return nil
 	}
 

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -66,6 +66,15 @@ func Test_FetcherShouldSentUpdateAfterFetchingAnEndpoint(t *testing.T) {
 	assert.Equal(t, StatusUpdate{URL: host + "/ping"}, <-statusUpdate)
 
 	input <- EndpointRequest{
+		URL:      host + "/optional",
+		Node:     dcos.Node{IP: "127.0.0.2", Role: dcos.MasterRole},
+		FileName: "optional-file",
+		Optional: true,
+	}
+
+	assert.Equal(t, StatusUpdate{URL: host + "/optional"}, <-statusUpdate)
+
+	input <- EndpointRequest{
 		URL:      host + "/error",
 		Node:     dcos.Node{IP: "127.0.0.2", Role: dcos.MasterRole},
 		FileName: "error_file",


### PR DESCRIPTION
Notable:
* API change for content returned by `/logs` of the diagnostics component. If this is an internal API to the diagnostics subsystem, and there are no other dependencies other than what's been changed in this PR, then we should be OK. Otherwise ... we'll need to consider an alternative approach here.

Related to https://jira.mesosphere.com/browse/DCOS-51618