### PR TITLE
Read providers configuration from multiple files

### DIFF
--- a/api/testdata/endpoint-config-2.json
+++ b/api/testdata/endpoint-config-2.json
@@ -1,0 +1,21 @@
+{
+  "HTTPEndpoints": [
+    {
+      "Port": 5050,
+      "Uri": "/__processes__",
+      "Role": ["master"]
+    }
+  ],
+  "LocalFiles": [
+    {
+      "Location": "/not/existing/file",
+      "Optional": true
+    }
+  ],
+  "LocalCommands": [
+    {
+      "Command": ["does", "not", "exist"],
+      "Optional": true
+    }
+  ]
+}

--- a/api/testdata/endpoint-config-3.json
+++ b/api/testdata/endpoint-config-3.json
@@ -1,0 +1,8 @@
+{
+  "LocalFiles": [
+    {
+      "Location": "/not/existing/file",
+      "Optional": false
+    }
+  ]
+}

--- a/api/testdata/endpoint-config.json
+++ b/api/testdata/endpoint-config.json
@@ -2,11 +2,6 @@
   "HTTPEndpoints": [
     {
       "Port": 5050,
-      "Uri": "/__processes__",
-      "Role": ["master"]
-    },
-    {
-      "Port": 5050,
       "Uri": "/master/state-summary",
       "Role": ["master"]
     },
@@ -54,10 +49,6 @@
     {
       "Location": "/var/lib/dcos/exhibitor/conf/zoo.cfg",
       "Role": ["master"]
-    },
-    {
-      "Location": "/not/existing/file",
-      "Optional": true
     }
   ],
   "LocalCommands": [
@@ -79,10 +70,6 @@
     },
     {
       "Command": ["echo", "OK"]
-    },
-    {
-      "Command": ["does", "not", "exist"],
-      "Optional": true
     }
   ]
 }

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -76,8 +76,8 @@ func init() {
 	// diagnostics job flags
 	daemonCmd.PersistentFlags().StringVar(&defaultConfig.FlagDiagnosticsBundleDir,
 		"diagnostics-bundle-dir", diagnosticsBundleDir, "Set a path to store diagnostic bundles")
-	daemonCmd.PersistentFlags().StringVar(&defaultConfig.FlagDiagnosticsBundleEndpointsConfigFile,
-		"endpoint-config", diagnosticsEndpointConfig,
+	daemonCmd.PersistentFlags().StringSliceVar(&defaultConfig.FlagDiagnosticsBundleEndpointsConfigFiles,
+		"endpoint-config", []string{diagnosticsEndpointConfig},
 		"Use endpoints_config.json")
 	daemonCmd.PersistentFlags().StringVar(&defaultConfig.FlagDiagnosticsBundleUnitsLogsSinceString,
 		"diagnostics-units-since", "24h", "Collect systemd units logs since")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -29,18 +29,48 @@ func Test_initConfig(t *testing.T) {
 	initConfig()
 
 	expected := &config.Config{
-		FlagRole:                                     "master",
-		FlagPort:                                     1050,
-		FlagPull:                                     true,
-		FlagMasterPort:                               1050,
-		FlagAgentPort:                                61001,
-		FlagPullInterval:                             60,
-		FlagPullTimeoutSec:                           3,
-		FlagUpdateHealthReportInterval:               60,
-		FlagExhibitorClusterStatusURL:                "http://127.0.0.1:8181/exhibitor/v1/cluster/status",
-		FlagDisableUnixSocket:                        true,
-		FlagDiagnosticsBundleDir:                     "diag-bundles",
-		FlagDiagnosticsBundleEndpointsConfigFile:     "dcos-diagnostics-endpoint-config.json",
+		FlagRole:                       "master",
+		FlagPort:                       1050,
+		FlagPull:                       true,
+		FlagMasterPort:                 1050,
+		FlagAgentPort:                  61001,
+		FlagPullInterval:               60,
+		FlagPullTimeoutSec:             3,
+		FlagUpdateHealthReportInterval: 60,
+		FlagExhibitorClusterStatusURL:  "http://127.0.0.1:8181/exhibitor/v1/cluster/status",
+		FlagDisableUnixSocket:          true,
+		FlagDiagnosticsBundleDir:       "diag-bundles",
+		FlagDiagnosticsBundleEndpointsConfigFiles:    []string{"dcos-diagnostics-endpoint-config.json"},
+		FlagDiagnosticsBundleUnitsLogsSinceString:    "24h",
+		FlagDiagnosticsJobTimeoutMinutes:             720,
+		FlagDiagnosticsJobGetSingleURLTimeoutMinutes: 2,
+		FlagCommandExecTimeoutSec:                    120,
+	}
+
+	assert.Equal(t, expected, defaultConfig)
+
+}
+
+
+func Test_initConfig_multiple_endpints_configs(t *testing.T) {
+	cfgFile = filepath.Join("testdata", "dcos-diagnostics-config-multiple-endpoints-configs.json")
+	defer func() { cfgFile = "" }()
+
+	initConfig()
+
+	expected := &config.Config{
+		FlagRole:                       "master",
+		FlagPort:                       1050,
+		FlagPull:                       true,
+		FlagMasterPort:                 1050,
+		FlagAgentPort:                  61001,
+		FlagPullInterval:               60,
+		FlagPullTimeoutSec:             3,
+		FlagUpdateHealthReportInterval: 60,
+		FlagExhibitorClusterStatusURL:  "http://127.0.0.1:8181/exhibitor/v1/cluster/status",
+		FlagDisableUnixSocket:          true,
+		FlagDiagnosticsBundleDir:       "diag-bundles",
+		FlagDiagnosticsBundleEndpointsConfigFiles:    []string{"1", "2"},
 		FlagDiagnosticsBundleUnitsLogsSinceString:    "24h",
 		FlagDiagnosticsJobTimeoutMinutes:             720,
 		FlagDiagnosticsJobGetSingleURLTimeoutMinutes: 2,

--- a/cmd/testdata/dcos-diagnostics-config-multiple-endpoints-configs.json
+++ b/cmd/testdata/dcos-diagnostics-config-multiple-endpoints-configs.json
@@ -1,0 +1,8 @@
+{
+  "role": "master",
+  "pull": true,
+  "diagnostics-bundle-dir": "diag-bundles",
+  "endpoint-config": ["1", "2"],
+  "no-unix-socket": true,
+  "agent-port": 61001
+}

--- a/config/config.go
+++ b/config/config.go
@@ -31,10 +31,10 @@ type Config struct {
 	FlagIAMConfig                  string `mapstructure:"iam-config"`
 
 	// diagnostics job flags
-	FlagDiagnosticsBundleDir                     string `mapstructure:"diagnostics-bundle-dir"`
-	FlagDiagnosticsBundleEndpointsConfigFile     string `mapstructure:"endpoint-config"`
-	FlagDiagnosticsBundleUnitsLogsSinceString    string `mapstructure:"diagnostics-units-since"`
-	FlagDiagnosticsJobTimeoutMinutes             int    `mapstructure:"diagnostics-job-timeout"`
-	FlagDiagnosticsJobGetSingleURLTimeoutMinutes int    `mapstructure:"diagnostics-url-timeout"`
-	FlagCommandExecTimeoutSec                    int    `mapstructure:"command-exec-timeout"`
+	FlagDiagnosticsBundleDir                     string   `mapstructure:"diagnostics-bundle-dir"`
+	FlagDiagnosticsBundleEndpointsConfigFiles    []string `mapstructure:"endpoint-config"`
+	FlagDiagnosticsBundleUnitsLogsSinceString    string   `mapstructure:"diagnostics-units-since"`
+	FlagDiagnosticsJobTimeoutMinutes             int      `mapstructure:"diagnostics-job-timeout"`
+	FlagDiagnosticsJobGetSingleURLTimeoutMinutes int      `mapstructure:"diagnostics-url-timeout"`
+	FlagCommandExecTimeoutSec                    int      `mapstructure:"command-exec-timeout"`
 }


### PR DESCRIPTION
This change replaces `FlagDiagnosticsBundleEndpointsConfigFile string` with `FlagDiagnosticsBundleEndpointsConfigFiles []string` to allow configure multiple files.
Files will be merged and last added file will override previous one (order is important). This change allows us to have common configuration between OSS and EE and keep EE specific configuration in separated file.

Fixes: [DCOS-51484](https://jira.mesosphere.com/browse/DCOS-51484)