### PR TITLE
Add bundle creation time gauge for Prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(BUILD_DIR)/$(BINARY_NAME): $(SRCS)
 	$(call inDocker,go build -mod=vendor -v -ldflags '$(LDFLAGS)' -o $(BUILD_DIR)/$(BINARY_NAME))
 
 .PHONY: build
-build: $(BUILD_DIR)/$(BINARY_NAME)
+build: docker $(BUILD_DIR)/$(BINARY_NAME)
 
 # install does not run in a docker container to build for the correct OS
 .PHONY: install

--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -123,6 +123,11 @@ var bundleCreationTimeHistogram = promauto.NewHistogram(prometheus.HistogramOpts
 	Help: "Time taken to create a bundle",
 })
 
+var bundleCreationTimeGauge = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "bundle_creation_time_seconds_gauge",
+	Help: "Time taken to create a bundle",
+})
+
 // start a diagnostics job
 func (j *DiagnosticsJob) run(req bundleCreateRequest) (createResponse, error) {
 
@@ -180,6 +185,7 @@ func (j *DiagnosticsJob) run(req bundleCreateRequest) (createResponse, error) {
 		j.runBackgroundJob(ctx, foundNodes)
 		duration := time.Since(start)
 		bundleCreationTimeHistogram.Observe(duration.Seconds())
+		bundleCreationTimeGauge.Set(duration.Seconds())
 	}()
 
 	var r createResponse


### PR DESCRIPTION
We need this gauge to be able to plot absolute bundle creation times
for each created bundle.

Also, I added the `docker` prerequisite to the `build` make target
because without this rule the Docker image for building the
dcos-diagnostics binary would not be built automatically.

refs https://jira.mesosphere.com/browse/DCOS_OSS-4962