### PR TITLE
Added timeout to systemd log reading; fixed `verbose` flag

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -971,7 +971,7 @@ func (j *DiagnosticsJob) dispatchLogs(ctx context.Context, provider, entity stri
 			return r, errors.New("Only DC/OS systemd units are available")
 		}
 		logrus.Debugf("dispatching a Unit %s", entity)
-		return units.ReadJournalOutputSince(entity, j.Cfg.FlagDiagnosticsBundleUnitsLogsSinceString)
+		return units.ReadJournalOutputSince(ctx, entity, j.Cfg.FlagDiagnosticsBundleUnitsLogsSinceString)
 	}
 
 	if provider == "files" {

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -338,7 +338,12 @@ func (h *handler) getUnitLogHandler(w http.ResponseWriter, r *http.Request) {
 	defer unitLogOut.Close()
 
 	log.Infof("Start read %s", vars["entity"])
-	io.Copy(w, unitLogOut)
+	_, err = io.Copy(w, unitLogOut)
+	if err != nil {
+		msg := fmt.Sprintf("Error writing unit log of %s: %s\n", vars["entity"], err)
+		log.Info(msg)
+		io.WriteString(w, msg)
+	}
 	log.Infof("Done read %s", vars["entity"])
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,12 @@ dcos-diagnostics daemon start an http server and polls the components health.
 		}
 		cmd.Help()
 	},
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if defaultConfig.FlagVerbose {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+		logrus.Infof("Log level: %s (%t)", logrus.GetLevel(), defaultConfig.FlagVerbose)
+	},
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/dcos/dcos-diagnostics/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/sirupsen/logrus"
 )
 
 func Test_initConfig(t *testing.T) {
@@ -81,4 +82,14 @@ func Test_initConfig_multiple_endpints_configs(t *testing.T) {
 
 	assert.Equal(t, expected, defaultConfig)
 
+}
+
+func TestPersistentPreRunSetsLogLevel(t *testing.T) {
+	assert.Equal(t, logrus.InfoLevel, logrus.GetLevel())
+	RootCmd.PersistentPreRun(nil, nil)
+	assert.Equal(t, logrus.InfoLevel, logrus.GetLevel())
+
+	defaultConfig.FlagVerbose = true
+	RootCmd.PersistentPreRun(nil, nil)
+	assert.Equal(t, logrus.DebugLevel, logrus.GetLevel())
 }

--- a/units/helpers.go
+++ b/units/helpers.go
@@ -1,0 +1,22 @@
+package units
+
+import (
+	"context"
+	"io"
+)
+
+type TimeoutReadCloser struct {
+	ctx context.Context
+	src io.ReadCloser
+}
+
+func (r *TimeoutReadCloser) Read(p []byte) (n int, err error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.src.Read(p)
+}
+
+func (r *TimeoutReadCloser) Close() error {
+	return r.src.Close()
+}

--- a/units/helpers_darwin.go
+++ b/units/helpers_darwin.go
@@ -1,11 +1,12 @@
 package units
 
 import (
+	"context"
 	"errors"
 	"io"
 )
 
 // ReadJournalOutputSince returns error since darwin does not support journal
-func ReadJournalOutputSince(unit, sinceString string) (io.ReadCloser, error) {
+func ReadJournalOutputSince(ctx context.Context, unit, sinceString string) (io.ReadCloser, error) {
 	return nil, errors.New("does not work on darwin")
 }

--- a/units/helpers_test.go
+++ b/units/helpers_test.go
@@ -1,9 +1,12 @@
 package units
 
 import (
+	"context"
 	"io/ioutil"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +17,7 @@ func TestReadJournalOutputSince_Windows(t *testing.T) {
 		t.Skip()
 	}
 
-	r, err := ReadJournalOutputSince("", "")
+	r, err := ReadJournalOutputSince(context.TODO(), "", "")
 	assert.Nil(t, r)
 	assert.EqualError(t, err, "there is no journal on Windows")
 }
@@ -24,11 +27,34 @@ func TestReadJournalOutputSince_Linux(t *testing.T) {
 		t.Skip()
 	}
 
-	r, err := ReadJournalOutputSince("not-existing.service", "")
+	ctxDeadline := time.Now().Add(1 * time.Hour) // this test shouldn't take longer than an hour, should it?
+	ctx, cancel := context.WithDeadline(context.Background(), ctxDeadline)
+	defer cancel()
+	r, err := ReadJournalOutputSince(ctx, "not-existing.service", "")
 	require.NoError(t, err)
 
 	data, err := ioutil.ReadAll(r)
 	require.NoError(t, err)
 
 	assert.Empty(t, data)
+
+	assert.IsType(t, &TimeoutReadCloser{}, r)
+	tr := r.(*TimeoutReadCloser)
+	deadline, ok := tr.ctx.Deadline()
+	assert.True(t, ok, "Context expected to have a deadline but it had none")
+	assert.Equal(t, ctxDeadline, deadline, "Deadline has unexpected value")
+}
+
+func TestTimedReaderShouldTimeOut(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now())
+	defer cancel()
+	src := ioutil.NopCloser(strings.NewReader("test"))
+	tr := TimeoutReadCloser{
+		ctx: ctx,
+		src: src,
+	}
+	buf := make([]byte, 1024)
+	n, err := tr.Read(buf)
+	assert.Equal(t, 0, n, "Expected 0 bytes from reader because it should have timed out before 1st read")
+	require.Error(t, err, "Reader should have returned an error because the deadline should have been reached")
 }

--- a/units/helpers_windows.go
+++ b/units/helpers_windows.go
@@ -6,6 +6,6 @@ import (
 )
 
 // ReadJournalOutputSince returns error since windows does not support journal
-func ReadJournalOutputSince(unit, sinceString string) (io.ReadCloser, error) {
+func ReadJournalOutputSince(ctx context.Context, unit, sinceString string) (io.ReadCloser, error) {
 	return nil, fmt.Errorf("there is no journal on Windows")
 }

--- a/units/helpers_windows.go
+++ b/units/helpers_windows.go
@@ -1,6 +1,7 @@
 package units
 
 import (
+	"context"
 	"fmt"
 	"io"
 )


### PR DESCRIPTION
This closes https://jira.mesosphere.com/browse/DCOS_OSS-5097

I added a TimeoutReadCloser to our units package that reads data from
an underlying ReadCloser only when the deadline of the given Context
has not been reached. Otherwise it stops reading and returns the error
retrieved from the Context (usually a DeadlineExceeded error).

When reading a systemd unit's log is interrupted we now log this fact
in the diagnostics output so that the consumer of the bundle knows
there's probably more in the journal than he sees.