### PR TITLE
Get rid of `fetchHistogram` global variable

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -67,7 +67,8 @@ type DiagnosticsJob struct {
 	JobEnded              time.Time
 	JobDuration           time.Duration
 	JobProgressPercentage float32
-	fetchVec              prometheus.ObserverVec
+	// This vector is used to collect the HTTP response times of all endpoints.
+	FetchPrometheusVector prometheus.ObserverVec
 }
 
 type logProviders struct {
@@ -313,7 +314,7 @@ func (j *DiagnosticsJob) collectDataFromNodes(ctx context.Context, nodes []dcos.
 
 	numberOfWorkers := j.Cfg.FlagDiagnosticsBundleFetchersCount
 	for i := 0; i < numberOfWorkers; i++ {
-		f, err := fetcher.New(j.Cfg.FlagDiagnosticsBundleDir, j.client, fetchReq, fetchStatusUpdate, fetchResponse, j.fetchVec)
+		f, err := fetcher.New(j.Cfg.FlagDiagnosticsBundleDir, j.client, fetchReq, fetchStatusUpdate, fetchResponse, j.FetchPrometheusVector)
 		if err != nil {
 			return nil, fmt.Errorf("could not start fetchers: %s", err)
 		}

--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -67,6 +67,7 @@ type DiagnosticsJob struct {
 	JobEnded              time.Time
 	JobDuration           time.Duration
 	JobProgressPercentage float32
+	fetchVec              prometheus.ObserverVec
 }
 
 type logProviders struct {
@@ -312,7 +313,7 @@ func (j *DiagnosticsJob) collectDataFromNodes(ctx context.Context, nodes []dcos.
 
 	numberOfWorkers := j.Cfg.FlagDiagnosticsBundleFetchersCount
 	for i := 0; i < numberOfWorkers; i++ {
-		f, err := fetcher.New(j.Cfg.FlagDiagnosticsBundleDir, j.client, fetchReq, fetchStatusUpdate, fetchResponse)
+		f, err := fetcher.New(j.Cfg.FlagDiagnosticsBundleDir, j.client, fetchReq, fetchStatusUpdate, fetchResponse, j.fetchVec)
 		if err != nil {
 			return nil, fmt.Errorf("could not start fetchers: %s", err)
 		}

--- a/api/diagnostics_test.go
+++ b/api/diagnostics_test.go
@@ -421,7 +421,7 @@ func TestGetStatusWhenJobIsRunning(t *testing.T) {
 	dt := &Dt{
 		Cfg:              cfg,
 		DtDCOSTools:      tools,
-		DtDiagnosticsJob: &DiagnosticsJob{Cfg: cfg, DCOSTools: tools, client: http.DefaultClient, fetchVec: mockHistogram},
+		DtDiagnosticsJob: &DiagnosticsJob{Cfg: cfg, DCOSTools: tools, client: http.DefaultClient, FetchPrometheusVector: mockHistogram},
 		MR:               &MonitoringResponse{},
 	}
 
@@ -479,7 +479,7 @@ func TestCreateBundle(t *testing.T) {
 	})).Once()
 	mockHistogram := &mocks.MockHistogram{}
 	mockHistogram.On("WithLabelValues", "/ping", "200").Return(mockObs).Once()
-	job := &DiagnosticsJob{Cfg: cfg, DCOSTools: tools, client: http.DefaultClient, fetchVec: mockHistogram}
+	job := &DiagnosticsJob{Cfg: cfg, DCOSTools: tools, client: http.DefaultClient, FetchPrometheusVector: mockHistogram}
 	dt := &Dt{
 		Cfg:              cfg,
 		DtDCOSTools:      tools,

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -22,6 +22,8 @@ import (
 	"github.com/dcos/dcos-diagnostics/dcos"
 	"github.com/dcos/dcos-go/dcos/http/transport"
 	"github.com/dcos/dcos-go/dcos/nodeutil"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -139,6 +141,10 @@ func startDiagnosticsDaemon() {
 		Transport: tr,
 		Cfg:       defaultConfig,
 		DCOSTools: DCOSTools,
+		FetchPrometheusVector: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name: "fetch_endpoint_time_seconds",
+			Help: "Time taken fetch single endpoint",
+		}, []string{"path", "statusCode"}),
 	}
 
 	err = diagnosticsJob.Init()

--- a/mocks/prometheus.go
+++ b/mocks/prometheus.go
@@ -1,0 +1,59 @@
+package mocks
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockObserver struct {
+	mock.Mock
+}
+
+func (m *MockObserver) Observe(v float64) {
+	m.Called(v)
+}
+
+type MockHistogram struct {
+	mock.Mock
+}
+
+func (m *MockHistogram) GetMetricWith(labels prometheus.Labels) (prometheus.Observer, error) {
+	args := m.Called(labels)
+	return args.Get(0).(prometheus.Observer), args.Error(1)
+}
+
+func (m *MockHistogram) GetMetricWithLabelValues(lvs ...string) (prometheus.Observer, error) {
+	args := m.Called(lvs)
+	return args.Get(0).(prometheus.Observer), args.Error(1)
+}
+
+func (m *MockHistogram) With(labels prometheus.Labels) prometheus.Observer {
+	args := m.Called(labels)
+	return args.Get(0).(prometheus.Observer)
+}
+
+func (m *MockHistogram) WithLabelValues(lvs ...string) prometheus.Observer {
+	new := make([]interface{}, len(lvs))
+	for i, v := range lvs {
+		new[i] = v
+	}
+	args := m.Called(new...)
+	return args.Get(0).(prometheus.Observer)
+}
+
+func (m *MockHistogram) CurryWith(labels prometheus.Labels) (prometheus.ObserverVec, error) {
+	args := m.Called(labels)
+	return args.Get(0).(prometheus.ObserverVec), args.Error(1)
+}
+
+func (m *MockHistogram) MustCurryWith(labels prometheus.Labels) prometheus.ObserverVec {
+	args := m.Called(labels)
+	return args.Get(0).(prometheus.ObserverVec)
+}
+func (m *MockHistogram) Describe(ch chan<- *prometheus.Desc) {
+	m.Called(ch)
+}
+
+func (m *MockHistogram) Collect(ch chan<- prometheus.Metric) {
+	m.Called(ch)
+}


### PR DESCRIPTION
The histogram is now injected into Fetcher structs so we can also unit
test its calls properly.

refs https://jira.mesosphere.com/browse/DCOS_OSS-5136