### PR TITLE
Remove requests logging

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -358,7 +358,7 @@ func wrapHandler(handler http.Handler, route routeHandler, dt *Dt) http.Handler 
 		h = noCacheMiddleware(h, dt)
 	}
 
-	return metricMiddleware(handlers.LoggingHandler(logrus.StandardLogger().Out, h))
+	return metricMiddleware(h)
 }
 
 func loadRoutes(router *mux.Router, dt *Dt) *mux.Router {


### PR DESCRIPTION
Logging all request is not necessary when we have metrics. Requests logs are polluting logs and it's harder to find interesting information. The same data can be obtained with metrics.

Reverts: c139d7679716de8bff12f94895a1a1941b68d998
Fixes: https://jira.mesosphere.com/browse/DCOS_OSS-5256