### PR TITLE
Decrease timeouts to be < than adminrouter timeout

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -709,7 +709,7 @@ func (j *DiagnosticsJob) cancel() (response diagnosticsReportResponse, err error
 		status := "Attempting to cancel a job on a remote host. POST " + url
 		logrus.Debug(status)
 		j.setStatus(status)
-		response, _, err := j.DCOSTools.Post(url, time.Duration(j.Cfg.FlagDiagnosticsJobGetSingleURLTimeoutMinutes)*time.Minute)
+		response, _, err := j.DCOSTools.Post(url, j.Cfg.GetHTTPTimeout())
 		if err != nil {
 			return prepareResponseWithErr(http.StatusServiceUnavailable, err)
 		}
@@ -949,8 +949,7 @@ func (j *DiagnosticsJob) Init() error {
 		}
 	}
 
-	timeout := time.Minute * time.Duration(j.Cfg.FlagDiagnosticsJobGetSingleURLTimeoutMinutes)
-	j.client = util.NewHTTPClient(timeout, j.Transport)
+	j.client = util.NewHTTPClient(j.Cfg.GetHTTPTimeout(), j.Transport)
 
 	return nil
 }

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -114,8 +114,7 @@ func startDiagnosticsDaemon() {
 		logrus.Fatalf("Could not init diagnostics job properly: %s", err)
 	}
 
-	urlTimeout := time.Minute * time.Duration(defaultConfig.FlagDiagnosticsJobGetSingleURLTimeoutMinutes)
-	collectors, err := api.LoadCollectors(defaultConfig, DCOSTools, util.NewHTTPClient(urlTimeout, tr))
+	collectors, err := api.LoadCollectors(defaultConfig, DCOSTools, util.NewHTTPClient(defaultConfig.GetHTTPTimeout(), tr))
 	if err != nil {
 		logrus.Fatalf("Could not init collectors properly: %s", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,7 @@ func init() {
 	daemonCmd.PersistentFlags().IntVar(&defaultConfig.FlagAgentPort, "agent-port", diagnosticsTCPPort,
 		"Use TCP port to connect to agents.")
 	daemonCmd.PersistentFlags().IntVar(&defaultConfig.FlagCommandExecTimeoutSec, "command-exec-timeout",
-		120, "Set command executing timeout")
+		50, "Set command executing timeout")
 	daemonCmd.PersistentFlags().BoolVar(&defaultConfig.FlagPull, "pull", defaultConfig.FlagPull,
 		"Try to pull runner from DC/OS hosts.")
 	daemonCmd.PersistentFlags().IntVar(&defaultConfig.FlagPullInterval, "pull-interval", 60,
@@ -123,7 +123,7 @@ func init() {
 		"diagnostics-job-timeout", 720,
 		"Set a global diagnostics job timeout")
 	daemonCmd.PersistentFlags().IntVar(&defaultConfig.FlagDiagnosticsJobGetSingleURLTimeoutMinutes,
-		"diagnostics-url-timeout", 2,
+		"diagnostics-url-timeout", 1,
 		"Set a local timeout for every single GET request to a log endpoint")
 	daemonCmd.PersistentFlags().IntVar(&defaultConfig.FlagDiagnosticsBundleFetchersCount,
 		"fetchers-count", 1,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	jwtt "github.com/spf13/jwalterweatherman"
@@ -59,12 +60,13 @@ func Test_initConfig(t *testing.T) {
 		FlagDiagnosticsBundleEndpointsConfigFiles:    []string{"dcos-diagnostics-endpoint-config.json"},
 		FlagDiagnosticsBundleUnitsLogsSinceString:    "24h",
 		FlagDiagnosticsJobTimeoutMinutes:             720,
-		FlagDiagnosticsJobGetSingleURLTimeoutMinutes: 2,
-		FlagCommandExecTimeoutSec:                    120,
+		FlagDiagnosticsJobGetSingleURLTimeoutMinutes: 1,
+		FlagCommandExecTimeoutSec:                    50,
 		FlagDiagnosticsBundleFetchersCount:           1,
 	}
 
 	assert.Equal(t, expected, defaultConfig)
+	assert.Equal(t, time.Minute, defaultConfig.GetHTTPTimeout())
 
 }
 
@@ -98,12 +100,13 @@ func Test_initConfig_multiple_endpints_configs(t *testing.T) {
 		FlagDiagnosticsBundleEndpointsConfigFiles:    []string{"1", "2"},
 		FlagDiagnosticsBundleUnitsLogsSinceString:    "24h",
 		FlagDiagnosticsJobTimeoutMinutes:             720,
-		FlagDiagnosticsJobGetSingleURLTimeoutMinutes: 2,
-		FlagCommandExecTimeoutSec:                    120,
+		FlagDiagnosticsJobGetSingleURLTimeoutMinutes: 1,
+		FlagCommandExecTimeoutSec:                    50,
 		FlagDiagnosticsBundleFetchersCount:           1,
 	}
 
 	assert.Equal(t, expected, defaultConfig)
+	assert.Equal(t, time.Minute, defaultConfig.GetHTTPTimeout())
 
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 var (
 	// Version of dcos-diagnostics code.
 	Version = "dev"
@@ -39,4 +41,8 @@ type Config struct {
 	FlagDiagnosticsJobGetSingleURLTimeoutMinutes int      `mapstructure:"diagnostics-url-timeout"`
 	FlagCommandExecTimeoutSec                    int      `mapstructure:"command-exec-timeout"`
 	FlagDiagnosticsBundleFetchersCount           int      `mapstructure:"fetchers-count"`
+}
+
+func (c Config) GetHTTPTimeout() time.Duration {
+	return time.Duration(c.FlagDiagnosticsJobGetSingleURLTimeoutMinutes) * time.Minute
 }


### PR DESCRIPTION
Admin router timeout is 60s our internal timeouts were 120s this leads to many [`504 Gateway Timeout`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) during bundle creation. This commit changes default timeouts to be less than 60s so we will have our internal timeout and do not need additional logic to handle 504 error.

Refs: https://stackoverflow.com/c/mesosphere/a/319/7
Fixes: https://jira.mesosphere.com/browse/DCOS_OSS-5255