### PR TITLE
Do not merge yet - Adds debug information to cluster bundles

### DIFF
--- a/api/rest/bundle_handler_test.go
+++ b/api/rest/bundle_handler_test.go
@@ -694,9 +694,8 @@ func TestIfE2E_(t *testing.T) {
 
 	t.Run("get status of not existing bundle-0", func(t *testing.T) {
 		bundle, err := client.Status(context.TODO(), testServer.URL, "bundle-0")
-		require.NoError(t, err)
-
-		assert.Equal(t, &Bundle{Status: Unknown}, bundle)
+		assert.Nil(t, bundle)
+		assert.IsType(t, &DiagnosticsBundleNotFoundError{}, err)
 	})
 
 	t.Run("create bundle-0", func(t *testing.T) {
@@ -714,7 +713,9 @@ func TestIfE2E_(t *testing.T) {
 		for { // busy wait for bundle
 			bundle, err := client.Status(context.TODO(), testServer.URL, "bundle-0")
 			require.NoError(t, err)
-			if bundle.Status == Done { break }
+			if bundle.Status == Done {
+				break
+			}
 		}
 
 		bundle, err := client.Status(context.TODO(), testServer.URL, "bundle-0")
@@ -774,9 +775,8 @@ func TestIfE2E_(t *testing.T) {
 
 	t.Run("delete bundle-0", func(t *testing.T) {
 
-		req, err := http.NewRequest(http.MethodDelete, testServer.URL + bundlesEndpoint+"/bundle-0", nil)
+		req, err := http.NewRequest(http.MethodDelete, testServer.URL+bundlesEndpoint+"/bundle-0", nil)
 		require.NoError(t, err)
-
 
 		rr, err := http.DefaultClient.Do(req)
 

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -153,7 +153,6 @@ func (d DiagnosticsClient) GetFile(ctx context.Context, node string, ID string, 
 		return err
 	}
 
-	// return the full path to the created file
 	return nil
 }
 

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -224,35 +224,3 @@ func remoteURL(node string, ID string) string {
 	url := fmt.Sprintf("%s%s/%s", node, bundlesEndpoint, ID)
 	return url
 }
-
-type DiagnosticsBundleNotFoundError struct {
-	id string
-}
-
-func (d *DiagnosticsBundleNotFoundError) Error() string {
-	return fmt.Sprintf("bundle %s not found", d.id)
-}
-
-type DiagnosticsBundleUnreadableError struct {
-	id string
-}
-
-func (d *DiagnosticsBundleUnreadableError) Error() string {
-	return fmt.Sprintf("bundle %s not readable", d.id)
-}
-
-type DiagnosticsBundleNotCompletedError struct {
-	id string
-}
-
-func (d *DiagnosticsBundleNotCompletedError) Error() string {
-	return fmt.Sprintf("bundle %s canceled or already deleted", d.id)
-}
-
-type DiagnosticsBundleAlreadyExists struct {
-	id string
-}
-
-func (d *DiagnosticsBundleAlreadyExists) Error() string {
-	return fmt.Sprintf("bundle %s already exists", d.id)
-}

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -67,9 +67,10 @@ func (d DiagnosticsClient) CreateBundle(ctx context.Context, node string, ID str
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusConflict {
+	switch {
+	case resp.StatusCode == http.StatusConflict:
 		return nil, &DiagnosticsBundleAlreadyExists{id: ID}
-	} else if resp.StatusCode != http.StatusOK {
+	case resp.StatusCode != http.StatusOK:
 		return nil, handleErrorCode(resp, url)
 	}
 
@@ -102,11 +103,12 @@ func (d DiagnosticsClient) Status(ctx context.Context, node string, ID string) (
 
 	bundle := &Bundle{}
 
-	if resp.StatusCode == http.StatusNotFound {
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
 		return nil, &DiagnosticsBundleNotFoundError{id: ID}
-	} else if resp.StatusCode == http.StatusInternalServerError {
+	case resp.StatusCode == http.StatusInternalServerError:
 		return nil, &DiagnosticsBundleUnreadableError{id: ID}
-	} else if resp.StatusCode != http.StatusOK {
+	case resp.StatusCode != http.StatusOK:
 		return nil, handleErrorCode(resp, url)
 	}
 
@@ -134,11 +136,12 @@ func (d DiagnosticsClient) GetFile(ctx context.Context, node string, ID string, 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
 		return &DiagnosticsBundleNotFoundError{id: ID}
-	} else if resp.StatusCode == http.StatusInternalServerError {
+	case resp.StatusCode == http.StatusInternalServerError:
 		return &DiagnosticsBundleUnreadableError{id: ID}
-	} else if resp.StatusCode != http.StatusOK {
+	case resp.StatusCode != http.StatusOK:
 		return handleErrorCode(resp, url)
 	}
 
@@ -201,13 +204,14 @@ func (d DiagnosticsClient) Delete(ctx context.Context, node string, id string) e
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotModified {
+	switch {
+	case resp.StatusCode == http.StatusNotModified:
 		return &DiagnosticsBundleNotCompletedError{id: id}
-	} else if resp.StatusCode == http.StatusNotFound {
+	case resp.StatusCode == http.StatusNotFound:
 		return &DiagnosticsBundleNotFoundError{id: id}
-	} else if resp.StatusCode == http.StatusInternalServerError {
+	case resp.StatusCode == http.StatusInternalServerError:
 		return &DiagnosticsBundleUnreadableError{id: id}
-	} else if resp.StatusCode != http.StatusOK {
+	case resp.StatusCode != http.StatusOK:
 		return handleErrorCode(resp, url)
 	}
 

--- a/api/rest/client_errors.go
+++ b/api/rest/client_errors.go
@@ -1,0 +1,37 @@
+package rest
+
+import (
+	"fmt"
+)
+
+type DiagnosticsBundleNotFoundError struct {
+	id string
+}
+
+func (d *DiagnosticsBundleNotFoundError) Error() string {
+	return fmt.Sprintf("bundle %s not found", d.id)
+}
+
+type DiagnosticsBundleUnreadableError struct {
+	id string
+}
+
+func (d *DiagnosticsBundleUnreadableError) Error() string {
+	return fmt.Sprintf("bundle %s not readable", d.id)
+}
+
+type DiagnosticsBundleNotCompletedError struct {
+	id string
+}
+
+func (d *DiagnosticsBundleNotCompletedError) Error() string {
+	return fmt.Sprintf("bundle %s canceled or already deleted", d.id)
+}
+
+type DiagnosticsBundleAlreadyExists struct {
+	id string
+}
+
+func (d *DiagnosticsBundleAlreadyExists) Error() string {
+	return fmt.Sprintf("bundle %s already exists", d.id)
+}

--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -200,8 +200,6 @@ func TestGetStatusReturnsErrorWhenResponseIs500(t *testing.T) {
 		client: testClient,
 	}
 	bundle, err := client.Status(context.TODO(), testServer.URL, "bundle-0")
-	//assert.Contains(t, err.Error(), "received unexpected status code [500] from")
-	//assert.Contains(t, err.Error(), ": 500 ERROR")
 	assert.IsType(t, &DiagnosticsBundleUnreadableError{}, err)
 	assert.Nil(t, bundle)
 }
@@ -222,8 +220,6 @@ func TestGetFileReturnsErrorWhenResponseIs500(t *testing.T) {
 		client: testClient,
 	}
 	err := client.GetFile(context.TODO(), testServer.URL, "bundle-0", "")
-	//assert.Contains(t, err.Error(), "received unexpected status code [500] from")
-	//assert.Contains(t, err.Error(), ": 500 ERROR")
 	assert.IsType(t, &DiagnosticsBundleUnreadableError{}, err)
 }
 
@@ -420,6 +416,5 @@ func TestDeleteWhenBundleUnreadable(t *testing.T) {
 	}
 
 	err := client.Delete(context.TODO(), testServer.URL, "bundle-0")
-	//assert.EqualError(t, err, "bundle bundle-0 could not be read")
 	assert.IsType(t, &DiagnosticsBundleUnreadableError{}, err)
 }

--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -145,9 +145,6 @@ func TestGetFile(t *testing.T) {
 }
 
 func TestGetStatusBundleHasStatusUnknownBundleIDNotFound(t *testing.T) {
-	expected := Bundle{
-		Status: Unknown,
-	}
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/system/health/v1/node/diagnostics/bundle-0", r.URL.Path)
 		assert.Equal(t, http.MethodGet, r.Method)
@@ -161,9 +158,9 @@ func TestGetStatusBundleHasStatusUnknownBundleIDNotFound(t *testing.T) {
 	client := DiagnosticsClient{
 		client: testClient,
 	}
-	bundle, err := client.Status(context.TODO(), testServer.URL, "bundle-0")
-	assert.NoError(t, err)
-	assert.EqualValues(t, expected, *bundle)
+	_, err := client.Status(context.TODO(), testServer.URL, "bundle-0")
+	assert.Error(t, err)
+	assert.IsType(t, &DiagnosticsBundleNotFoundError{}, err)
 }
 
 func TestCreateReturnsErrorWhenResponseIs500(t *testing.T) {
@@ -203,8 +200,9 @@ func TestGetStatusReturnsErrorWhenResponseIs500(t *testing.T) {
 		client: testClient,
 	}
 	bundle, err := client.Status(context.TODO(), testServer.URL, "bundle-0")
-	assert.Contains(t, err.Error(), "received unexpected status code [500] from")
-	assert.Contains(t, err.Error(), ": 500 ERROR")
+	//assert.Contains(t, err.Error(), "received unexpected status code [500] from")
+	//assert.Contains(t, err.Error(), ": 500 ERROR")
+	assert.IsType(t, &DiagnosticsBundleUnreadableError{}, err)
 	assert.Nil(t, bundle)
 }
 
@@ -224,8 +222,9 @@ func TestGetFileReturnsErrorWhenResponseIs500(t *testing.T) {
 		client: testClient,
 	}
 	err := client.GetFile(context.TODO(), testServer.URL, "bundle-0", "")
-	assert.Contains(t, err.Error(), "received unexpected status code [500] from")
-	assert.Contains(t, err.Error(), ": 500 ERROR")
+	//assert.Contains(t, err.Error(), "received unexpected status code [500] from")
+	//assert.Contains(t, err.Error(), ": 500 ERROR")
+	assert.IsType(t, &DiagnosticsBundleUnreadableError{}, err)
 }
 
 func TestClientReturnsErrorWhenNodeIsInvalid(t *testing.T) {
@@ -421,5 +420,6 @@ func TestDeleteWhenBundleUnreadable(t *testing.T) {
 	}
 
 	err := client.Delete(context.TODO(), testServer.URL, "bundle-0")
-	assert.EqualError(t, err, "bundle bundle-0 could not be read")
+	//assert.EqualError(t, err, "bundle bundle-0 could not be read")
+	assert.IsType(t, &DiagnosticsBundleUnreadableError{}, err)
 }

--- a/api/rest/cluster_bundle_handler.go
+++ b/api/rest/cluster_bundle_handler.go
@@ -1,0 +1,337 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dcos/dcos-diagnostics/dcos"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+)
+
+// ClusterBundleHandler is a handler that will create and manage cluster-wide
+// diagnostics bundles
+type ClusterBundleHandler struct {
+	workDir    string
+	coord      coordinator
+	client     Client
+	tools      dcos.Tooler
+	timeout    time.Duration
+	clock      Clock
+	urlBuilder dcos.NodeURLBuilder
+}
+
+func NewClusterBundleHandler(c coordinator, client Client, tools dcos.Tooler, workDir string, timeout time.Duration,
+	clock Clock, urlBuilder dcos.NodeURLBuilder) *ClusterBundleHandler {
+
+	return &ClusterBundleHandler{
+		coord:      c,
+		client:     client,
+		workDir:    workDir,
+		timeout:    timeout,
+		tools:      tools,
+		clock:      clock,
+		urlBuilder: urlBuilder,
+	}
+}
+
+// Create will send the initial creation request for the bundle to all nodes. The created
+// bundle will exist on the called master node
+func (c *ClusterBundleHandler) Create(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	if c.bundleExists(id) {
+		writeJSONError(w, http.StatusConflict, fmt.Errorf("bundle %s already exists", id))
+		return
+	}
+
+	bundleWorkDir := filepath.Join(c.workDir, id)
+	err := os.MkdirAll(bundleWorkDir, dirPerm)
+	if err != nil {
+		writeJSONError(w, http.StatusInsufficientStorage, fmt.Errorf("could not create bundle %s workdir: %s", id, err))
+		return
+	}
+
+	stateFilePath := filepath.Join(c.workDir, id, stateFileName)
+
+	bundle := Bundle{
+		ID:      id,
+		Started: c.clock.Now(),
+		Status:  Started,
+	}
+
+	bundleStatus := jsonMarshal(bundle)
+	err = ioutil.WriteFile(stateFilePath, bundleStatus, filePerm)
+	if err != nil {
+		writeJSONError(w, http.StatusInsufficientStorage, fmt.Errorf("could not update state file %s: %s", id, err))
+		return
+	}
+
+	dataFile, err := os.Create(filepath.Join(c.workDir, id, dataFileName))
+	if err != nil {
+		writeJSONError(w, http.StatusInsufficientStorage, fmt.Errorf("could not create data file %s: %s", id, err))
+		return
+	}
+	masters, err := c.tools.GetMasterNodes()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, fmt.Errorf("error getting master nodes for bundle %s: %s", id, err))
+		return
+	}
+	agents, err := c.tools.GetAgentNodes()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, fmt.Errorf("error getting agent nodes for bundle %s: %s", id, err))
+		return
+	}
+
+	allNodes := append(masters, agents...)
+	nodes := make([]node, 0, len(allNodes))
+	for _, n := range allNodes {
+		ip := net.ParseIP(n.IP)
+		// govet seems to have an issue with err shadowing a previous declaration, not sure why
+		//nolint:govet
+		url, err := c.urlBuilder.BaseURL(ip, n.Role)
+		if err != nil {
+			logrus.WithField("bundle", id).WithField("node", ip).WithField("role", n.Role).WithError(err).Error("unable to build base URL for node, skipping")
+			continue
+		}
+		nodes = append(nodes, node{
+			Role:    n.Role,
+			IP:      ip,
+			baseURL: url,
+		})
+	}
+
+	//TODO(janisz): use context cancel function to cancel bundle creation https://jira.mesosphere.com/browse/DCOS_OSS-5222
+	//nolint:govet
+	ctx, _ := context.WithTimeout(context.Background(), c.timeout)
+
+	localBundleID, err := uuid.NewUUID()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, fmt.Errorf("unable to create local bundle id for bundle %s: %s", id, err))
+		return
+	}
+	statuses := c.coord.CreateBundle(ctx, localBundleID.String(), nodes)
+
+	go c.waitAndCollectRemoteBundle(ctx, &bundle, len(nodes), dataFile, stateFilePath, statuses)
+
+	write(w, bundleStatus)
+}
+
+func (c *ClusterBundleHandler) waitAndCollectRemoteBundle(ctx context.Context, bundle *Bundle, numBundles int,
+	dataFile io.WriteCloser, stateFilePath string, statuses <-chan bundleStatus) {
+
+	defer dataFile.Close()
+
+	bundleFilePath, err := c.coord.CollectBundle(ctx, bundle.ID, numBundles, statuses)
+	if err != nil {
+		bundle.Errors = append(bundle.Errors, err.Error())
+	}
+	bundle.Stopped = c.clock.Now()
+	bundle.Status = Done
+
+	err = ioutil.WriteFile(stateFilePath, jsonMarshal(bundle), filePerm)
+	if err != nil {
+		logrus.WithError(err).WithField("ID", bundle.ID).Error("Could not update state file.")
+		return
+	}
+
+	bundleFile, err := os.Open(bundleFilePath)
+	if err != nil {
+		logrus.WithError(err).WithField("ID", bundle.ID).Error("unable to open bundle for copying")
+		return
+	}
+
+	_, err = io.Copy(dataFile, bundleFile)
+	if err != nil {
+		logrus.WithError(err).WithField("ID", bundle.ID).Error("unable to copy bundle from temp dir working directory")
+		return
+	}
+}
+
+// List will get a list of all bundles available across all masters
+func (c *ClusterBundleHandler) List(w http.ResponseWriter, r *http.Request) {
+	_, err := c.getClusterNodes()
+	if err != nil {
+		// TODO
+	}
+}
+
+// Status will return the status of a given bundle, proxying the call to the appropriate master
+func (c *ClusterBundleHandler) Status(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	masters, err := c.getMasterNodes()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, fmt.Errorf("unable to get list of master nodes: %s", err))
+		return
+	}
+
+	ctx := context.TODO()
+
+	// TODO: parallelize this
+	// TODO: it's very possible that we can have duplicate node IDs for the local bundles that will be generated on the master
+	var foundBundle *Bundle
+	for _, n := range masters {
+		bundle, err := c.client.Status(ctx, n.baseURL, id)
+		if err == nil {
+			foundBundle = bundle
+			break
+		}
+	}
+
+	if foundBundle == nil {
+		writeJSONError(w, http.StatusNotFound, fmt.Errorf("bundle %s did not exist on any masters", id))
+		return
+	}
+	write(w, jsonMarshal(foundBundle))
+}
+
+// Delete will delete a given bundle, proxying the call if the given bundle exists
+// on a different master
+func (c *ClusterBundleHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	_ = vars["id"]
+
+	_, err := c.getMasterNodes()
+	if err != nil {
+		// TODO
+	}
+}
+
+// Download will download the given bundle, proxying the call to the appropriate master
+func (c *ClusterBundleHandler) Download(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	_ = vars["id"]
+
+	_, err := c.getClusterNodes()
+	if err != nil {
+		// TODO
+	}
+}
+
+func (c *ClusterBundleHandler) getClusterNodes() ([]node, error) {
+	masters, err := c.getMasterNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	agents, err := c.getAgentNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(masters, agents...), nil
+}
+
+func (c *ClusterBundleHandler) getMasterNodes() ([]node, error) {
+	masters, err := c.tools.GetMasterNodes()
+	if err != nil {
+		return nil, err
+	}
+	nodes := []node{}
+	for _, n := range masters {
+		ip := net.ParseIP(n.IP)
+		// govet seems to have an issue with err shadowing a previous declaration, not sure why
+		url, err := c.urlBuilder.BaseURL(ip, n.Role)
+		if err != nil {
+			logrus.WithField("node", ip).WithField("role", n.Role).WithError(err).Error("unable to build base URL for node, skipping")
+			continue
+		}
+		nodes = append(nodes, node{
+			Role:    n.Role,
+			IP:      ip,
+			baseURL: url,
+		})
+	}
+
+	return nodes, nil
+}
+
+func (c *ClusterBundleHandler) getAgentNodes() ([]node, error) {
+	agents, err := c.tools.GetAgentNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := []node{}
+	for _, n := range agents {
+		ip := net.ParseIP(n.IP)
+		// govet seems to have an issue with err shadowing a previous declaration, not sure why
+		url, err := c.urlBuilder.BaseURL(ip, n.Role)
+		if err != nil {
+			logrus.WithField("node", ip).WithField("role", n.Role).WithError(err).Error("unable to build base URL for node, skipping")
+			continue
+		}
+		nodes = append(nodes, node{
+			Role:    n.Role,
+			IP:      ip,
+			baseURL: url,
+		})
+	}
+
+	return nodes, nil
+}
+
+func (c *ClusterBundleHandler) bundleExists(id string) bool {
+	s, err := os.Stat(filepath.Join(c.workDir, id))
+	if os.IsNotExist(err) {
+		return false
+	}
+	if !s.IsDir() {
+		// If this is a file then it's not a valid bundle
+		return false
+	}
+	return true
+}
+
+func (c *ClusterBundleHandler) getBundleState(id string) (Bundle, error) {
+	bundle := Bundle{
+		ID:     id,
+		Status: Unknown,
+	}
+
+	stateFilePath := filepath.Join(c.workDir, id, stateFileName)
+	rawState, err := ioutil.ReadFile(stateFilePath)
+	if err != nil {
+		return bundle, fmt.Errorf("could not read state file for bundle %s: %s", id, err)
+	}
+
+	err = json.Unmarshal(rawState, &bundle)
+	if err != nil {
+		return bundle, fmt.Errorf("could not unmarshal state file %s: %s", id, err)
+	}
+
+	if bundle.Status == Deleted || bundle.Status == Canceled || bundle.Status == Unknown {
+		return bundle, nil
+	}
+
+	dataFileStat, err := os.Stat(filepath.Join(c.workDir, id, dataFileName))
+	if err != nil {
+		bundle.Status = Unknown
+		return bundle, fmt.Errorf("could not stat data file %s: %s", id, err)
+	}
+
+	if bundle.Size != dataFileStat.Size() {
+		bundle.Size = dataFileStat.Size()
+		// Update status files
+		bundleStatus := jsonMarshal(bundle)
+		err = ioutil.WriteFile(stateFilePath, bundleStatus, filePerm)
+		if err != nil {
+			return bundle, fmt.Errorf("could not update state file %s: %s", id, err)
+		}
+	}
+
+	return bundle, nil
+}

--- a/api/rest/cluster_bundle_handler.go
+++ b/api/rest/cluster_bundle_handler.go
@@ -23,7 +23,7 @@ import (
 // diagnostics bundles
 type ClusterBundleHandler struct {
 	workDir    string
-	coord      coordinator
+	coord      Coordinator
 	client     Client
 	tools      dcos.Tooler
 	timeout    time.Duration
@@ -31,8 +31,8 @@ type ClusterBundleHandler struct {
 	urlBuilder dcos.NodeURLBuilder
 }
 
-func NewClusterBundleHandler(c coordinator, client Client, tools dcos.Tooler, workDir string, timeout time.Duration,
-	clock Clock, urlBuilder dcos.NodeURLBuilder) *ClusterBundleHandler {
+func NewClusterBundleHandler(c Coordinator, client Client, tools dcos.Tooler, workDir string, timeout time.Duration,
+	urlBuilder dcos.NodeURLBuilder) *ClusterBundleHandler {
 
 	return &ClusterBundleHandler{
 		coord:      c,
@@ -40,7 +40,7 @@ func NewClusterBundleHandler(c coordinator, client Client, tools dcos.Tooler, wo
 		workDir:    workDir,
 		timeout:    timeout,
 		tools:      tools,
-		clock:      clock,
+		clock:      &realClock{},
 		urlBuilder: urlBuilder,
 	}
 }
@@ -129,7 +129,7 @@ func (c *ClusterBundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *ClusterBundleHandler) waitAndCollectRemoteBundle(ctx context.Context, bundle *Bundle, numBundles int,
-	dataFile io.WriteCloser, stateFilePath string, statuses <-chan bundleStatus) {
+	dataFile io.WriteCloser, stateFilePath string, statuses <-chan BundleStatus) {
 
 	defer dataFile.Close()
 
@@ -193,7 +193,7 @@ func (c *ClusterBundleHandler) Status(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	// TODO: parallelize this
 	// TODO: it's very possible that we can have duplicate node IDs for the local bundles that will be generated on the master

--- a/api/rest/cluster_bundle_handler.go
+++ b/api/rest/cluster_bundle_handler.go
@@ -122,7 +122,7 @@ func (c *ClusterBundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	report := bundleReport{Id: localBundleID.String()}
+	report := newBundleReport(localBundleID.String())
 	statuses := c.coord.CreateBundle(ctx, localBundleID.String(), nodes, report)
 
 	go c.waitAndCollectRemoteBundle(ctx, &bundle, report, dataFile, stateFilePath, statuses)

--- a/api/rest/cluster_bundle_handler_test.go
+++ b/api/rest/cluster_bundle_handler_test.go
@@ -44,15 +44,15 @@ func TestRemoteBundleCreationConflictErrorWhenBundleExists(t *testing.T) {
 	client := new(MockClient)
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleEndpoint, bh.Create).Methods(http.MethodPut)
@@ -100,15 +100,15 @@ func TestDeleteBundle(t *testing.T) {
 	client.On("Delete", ctx, "http://192.0.2.5", id).Return(&DiagnosticsBundleNotFoundError{id: id})
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleEndpoint, bh.Delete).Methods(http.MethodDelete)
@@ -156,15 +156,15 @@ func TestDeleteAlreadyDeletedBundle(t *testing.T) {
 	client.On("Delete", ctx, "http://192.0.2.5", id).Return(&DiagnosticsBundleNotFoundError{id: id})
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleEndpoint, bh.Delete).Methods(http.MethodDelete)
@@ -212,15 +212,15 @@ func TestDeleteBundleThatIsntFound(t *testing.T) {
 	client.On("Delete", ctx, "http://192.0.2.5", id).Return(&DiagnosticsBundleNotFoundError{id: id})
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleEndpoint, bh.Delete).Methods(http.MethodDelete)
@@ -268,15 +268,15 @@ func TestDeleteUnreadableBundle(t *testing.T) {
 	client.On("Delete", ctx, "http://192.0.2.5", id).Return(&DiagnosticsBundleNotFoundError{id: id})
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleEndpoint, bh.Delete).Methods(http.MethodDelete)
@@ -328,15 +328,15 @@ func TestStatusForBundle(t *testing.T) {
 	client.On("Status", ctx, "http://192.0.2.5", "bundle-0").Return(nil, fmt.Errorf("asdf"))
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleEndpoint, bh.Status).Methods(http.MethodGet)
@@ -390,15 +390,15 @@ func TestStatusOnMissingBundle(t *testing.T) {
 	client.On("Status", ctx, "http://192.0.2.5", id).Return(nil, &DiagnosticsBundleNotFoundError{id: id})
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleEndpoint, bh.Status).Methods(http.MethodGet)
@@ -436,15 +436,15 @@ func TestStatusForUnreadableBundle(t *testing.T) {
 	client.On("Status", ctx, "http://192.0.2.2", id).Return(nil, &DiagnosticsBundleUnreadableError{id: id})
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleEndpoint, bh.Status).Methods(http.MethodGet)
@@ -507,15 +507,15 @@ func TestDownloadBundle(t *testing.T) {
 	})
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleFileEndpoint, bh.Download).Methods(http.MethodGet)
@@ -565,15 +565,15 @@ func TestDownloadMissingBundle(t *testing.T) {
 	client.On("Status", ctx, "http://192.0.2.5", id).Return(nil, &DiagnosticsBundleNotFoundError{id: id})
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleFileEndpoint, bh.Download).Methods(http.MethodGet)
@@ -621,15 +621,15 @@ func TestDownloadUnreadableBundle(t *testing.T) {
 	client.On("Status", ctx, "http://192.0.2.5", id).Return(nil, &DiagnosticsBundleUnreadableError{id: id})
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleFileEndpoint, bh.Download).Methods(http.MethodGet)
@@ -688,15 +688,15 @@ func TestListWithBundlesOnMultipleMasters(t *testing.T) {
 	client.On("List", ctx, "http://192.0.2.5").Return([]*Bundle{expectedBundles[2]}, nil)
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundlesEndpoint, bh.List).Methods(http.MethodGet)
@@ -764,15 +764,15 @@ func TestRemoteBundleCreation(t *testing.T) {
 	client.On("Delete", ctx, "http://192.0.2.2", "bundle-0").Return(nil)
 
 	coord := new(mockCoordinator)
-	bh := NewClusterBundleHandler(
-		coord,
-		client,
-		tools,
-		workdir,
-		time.Second,
-		&MockClock{now: now},
-		MockURLBuilder{},
-	)
+	bh := ClusterBundleHandler{
+		workDir:    workdir,
+		coord:      coord,
+		client:     client,
+		tools:      tools,
+		timeout:    time.Second,
+		clock:      &MockClock{now: now},
+		urlBuilder: MockURLBuilder{},
+	}
 
 	router := mux.NewRouter()
 	router.HandleFunc(bundleEndpoint, bh.Create).Methods(http.MethodPut)
@@ -873,12 +873,12 @@ func TestRemoteBundleCreation(t *testing.T) {
 
 type mockCoordinator struct{}
 
-func (c mockCoordinator) CreateBundle(ctx context.Context, id string, nodes []node) <-chan bundleStatus {
-	statuses := make(chan bundleStatus, len(nodes))
+func (c mockCoordinator) CreateBundle(ctx context.Context, id string, nodes []node) <-chan BundleStatus {
+	statuses := make(chan BundleStatus, len(nodes))
 
 	for _, n := range nodes {
 		node := n
-		statuses <- bundleStatus{
+		statuses <- BundleStatus{
 			id:   id,
 			node: node,
 			done: true,
@@ -888,7 +888,7 @@ func (c mockCoordinator) CreateBundle(ctx context.Context, id string, nodes []no
 	return statuses
 }
 
-func (c mockCoordinator) CollectBundle(ctx context.Context, id string, numBundles int, statuses <-chan bundleStatus) (string, error) {
+func (c mockCoordinator) CollectBundle(ctx context.Context, id string, numBundles int, statuses <-chan BundleStatus) (string, error) {
 	return filepath.Abs(filepath.Join("testdata", "combined.zip"))
 }
 

--- a/api/rest/cluster_bundle_handler_test.go
+++ b/api/rest/cluster_bundle_handler_test.go
@@ -640,7 +640,7 @@ func TestDownloadUnreadableBundle(t *testing.T) {
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 }
 
 func TestListWithBundlesOnMultipleMasters(t *testing.T) {

--- a/api/rest/cluster_bundle_handler_test.go
+++ b/api/rest/cluster_bundle_handler_test.go
@@ -873,7 +873,7 @@ func TestRemoteBundleCreation(t *testing.T) {
 
 type mockCoordinator struct{}
 
-func (c mockCoordinator) CreateBundle(ctx context.Context, id string, nodes []node) <-chan BundleStatus {
+func (c mockCoordinator) CreateBundle(ctx context.Context, id string, nodes []node, report bundleReport) <-chan BundleStatus {
 	statuses := make(chan BundleStatus, len(nodes))
 
 	for _, n := range nodes {
@@ -888,7 +888,7 @@ func (c mockCoordinator) CreateBundle(ctx context.Context, id string, nodes []no
 	return statuses
 }
 
-func (c mockCoordinator) CollectBundle(ctx context.Context, id string, numBundles int, statuses <-chan BundleStatus) (string, error) {
+func (c mockCoordinator) CollectBundle(ctx context.Context, id string, report bundleReport, statuses <-chan BundleStatus) (string, error) {
 	return filepath.Abs(filepath.Join("testdata", "combined.zip"))
 }
 

--- a/api/rest/cluster_bundle_handler_test.go
+++ b/api/rest/cluster_bundle_handler_test.go
@@ -1,0 +1,290 @@
+package rest
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dcos/dcos-diagnostics/dcos"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteBundleCreationConflictErrorWhenBundleExists(t *testing.T) {
+}
+
+func TestRemoteBundleCreationFileSystemError(t *testing.T) {
+}
+
+func TestDeleteBundleOnOtherMaster(t *testing.T) {
+}
+
+func TestDeleteAlreadyDeletedBundle(t *testing.T) {
+}
+
+func TestDeleteBundleThatNeverExisted(t *testing.T) {
+}
+
+func TestDeleteUnreadableBundle(t *testing.T) {
+}
+
+func TestStatusForBundleOnOtherMaster(t *testing.T) {
+	workdir, err := ioutil.TempDir("", "work-dir")
+	require.NoError(t, err)
+	err = os.RemoveAll(workdir) // just check if dcos-diagnostics will create whole path to workdir
+	require.NoError(t, err)
+
+	now, err := time.Parse(time.RFC3339, "2015-08-05T08:40:51.620Z")
+	require.NoError(t, err)
+
+	tools := new(MockedTools)
+	tools.On("GetMasterNodes").Return([]dcos.Node{
+		{
+			Role: "master",
+			IP:   "192.0.2.2",
+		},
+		{
+			Role: "master",
+			IP:   "192.0.2.4",
+		},
+		{
+			Role: "master",
+			IP:   "192.0.2.5",
+		},
+	}, nil)
+
+	ctx := context.TODO()
+
+	client := new(MockClient)
+	client.On("Status", ctx, "http://192.0.2.2", "bundle-0").Return(nil, fmt.Errorf("asdf"))
+	client.On("Status", ctx, "http://192.0.2.4", "bundle-0").Return(&Bundle{
+		ID:      "bundle-0",
+		Status:  Done,
+		Started: now,
+		Stopped: now.Add(1 * time.Hour),
+	}, nil)
+	client.On("Status", ctx, "http://192.0.2.5", "bundle-0").Return(nil, fmt.Errorf("asdf"))
+
+	coord := new(mockCoordinator)
+	bh := NewClusterBundleHandler(
+		coord,
+		client,
+		tools,
+		workdir,
+		time.Second,
+		&MockClock{now: now},
+		MockURLBuilder{},
+	)
+
+	router := mux.NewRouter()
+	router.HandleFunc(bundleEndpoint, bh.Status).Methods(http.MethodGet)
+
+	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle-0", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.JSONEq(t, string(jsonMarshal(Bundle{
+		ID:      "bundle-0",
+		Status:  Done,
+		Started: now.Add(time.Hour),
+	})), rr.Body.String())
+}
+
+func TestStatusOnMissingBundle(t *testing.T) {
+}
+
+func TestStatusForUnreadableBunde(t *testing.T) {
+}
+
+func TestDownloadBundleOnOtherMaster(t *testing.T) {
+}
+
+func TestDownloadMissingBundle(t *testing.T) {
+}
+
+func TestDownloadUnreadableBundle(t *testing.T) {
+}
+
+func TestListWithBundlesOnOtherMasters(t *testing.T) {
+}
+
+func TestRemoteBundleCreation(t *testing.T) {
+	workdir, err := ioutil.TempDir("", "work-dir")
+	require.NoError(t, err)
+	err = os.RemoveAll(workdir) // just check if dcos-diagnostics will create whole path to workdir
+	require.NoError(t, err)
+
+	now, err := time.Parse(time.RFC3339, "2015-08-05T08:40:51.620Z")
+	require.NoError(t, err)
+
+	tools := new(MockedTools)
+	tools.On("GetMasterNodes").Return([]dcos.Node{
+		{
+			Leader: true,
+			Role:   "master",
+			IP:     "192.0.2.2",
+		},
+	}, nil)
+	tools.On("GetAgentNodes").Return([]dcos.Node{
+		{
+			Role: "agent",
+			IP:   "192.0.2.1",
+		},
+		{
+			Role: "agent",
+			IP:   "192.0.2.3",
+		},
+	}, nil)
+
+	ctx := context.TODO()
+
+	client := new(MockClient)
+	client.On("Status", ctx, "http://192.0.2.2", "bundle-0").Return(nil, fmt.Errorf("asdf"))
+
+	coord := new(mockCoordinator)
+	bh := NewClusterBundleHandler(
+		coord,
+		client,
+		tools,
+		workdir,
+		time.Second,
+		&MockClock{now: now},
+		MockURLBuilder{},
+	)
+
+	router := mux.NewRouter()
+	router.HandleFunc(bundleEndpoint, bh.Create).Methods(http.MethodPut)
+	router.HandleFunc(bundleEndpoint, bh.Status).Methods(http.MethodGet)
+	router.HandleFunc(bundleEndpoint, bh.Delete).Methods(http.MethodDelete)
+	router.HandleFunc(bundleFileEndpoint, bh.Download).Methods(http.MethodGet)
+
+	t.Run("send creation request", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodPut, bundlesEndpoint+"/bundle-0", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.JSONEq(t, string(jsonMarshal(Bundle{
+			ID:      "bundle-0",
+			Status:  Started,
+			Started: now.Add(time.Hour),
+		})), rr.Body.String())
+
+	})
+
+	t.Run("get status", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+
+		tries := 0
+		retryLimit := 100
+		for { // busy wait for bundle
+			time.Sleep(time.Millisecond)
+			req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle-0", nil)
+			require.NoError(t, err)
+
+			rr = httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+
+			if strings.Contains(rr.Body.String(), Done.String()) {
+				break
+			}
+			tries++
+			// keeps the test suite from hanging if something is wrong
+			require.True(t, tries < retryLimit, "status wait loop exceeded retry limit")
+		}
+
+		req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle-0", nil)
+		require.NoError(t, err)
+
+		rr = httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.JSONEq(t, string(jsonMarshal(Bundle{
+			ID:      "bundle-0",
+			Size:    727,
+			Status:  Done,
+			Started: now.Add(time.Hour),
+			Stopped: now.Add(2 * time.Hour),
+			Errors:  []string{},
+		})), rr.Body.String())
+	})
+
+	t.Run("get bundle-0 file and validate it", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle-0/file", nil)
+		require.NoError(t, err)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		reader, err := zip.NewReader(bytes.NewReader(rr.Body.Bytes()), int64(len(rr.Body.Bytes())))
+		require.NoError(t, err)
+
+		expectedContents := []string{
+			"192.0.2.1/",
+			"192.0.2.1/test.txt",
+			"192.0.2.2/",
+			"192.0.2.2/test.txt",
+			"192.0.2.3/",
+			"192.0.2.3/test.txt",
+		}
+
+		filenames := []string{}
+		for _, f := range reader.File {
+			filenames = append(filenames, f.Name)
+		}
+		sort.Strings(filenames)
+
+		assert.Equal(t, expectedContents, filenames)
+	})
+
+	t.Run("delete bundle", func(t *testing.T) {
+		//TODO: implement this
+		assert.True(t, false)
+	})
+}
+
+type mockCoordinator struct{}
+
+func (c mockCoordinator) CreateBundle(ctx context.Context, id string, nodes []node) <-chan bundleStatus {
+	statuses := make(chan bundleStatus, len(nodes))
+
+	for _, n := range nodes {
+		node := n
+		statuses <- bundleStatus{
+			id:   id,
+			node: node,
+			done: true,
+		}
+	}
+
+	return statuses
+}
+
+func (c mockCoordinator) CollectBundle(ctx context.Context, id string, numBundles int, statuses <-chan bundleStatus) (string, error) {
+	return filepath.Abs(filepath.Join("testdata", "combined.zip"))
+}
+
+type MockURLBuilder struct{}
+
+func (m MockURLBuilder) BaseURL(ip net.IP, _ string) (string, error) {
+	return fmt.Sprintf("http://%s", ip), nil
+}

--- a/api/rest/coordinator.go
+++ b/api/rest/coordinator.go
@@ -25,7 +25,7 @@ type BundleStatus struct {
 }
 
 type bundleReport struct {
-	Id    string                      `json:"id"`
+	ID    string                      `json:"id"`
 	Nodes map[string]bundleNodeReport `json:"nodes"`
 }
 
@@ -36,7 +36,7 @@ type bundleNodeReport struct {
 
 func newBundleReport(id string) bundleReport {
 	return bundleReport{
-		Id:    id,
+		ID:    id,
 		Nodes: make(map[string]bundleNodeReport),
 	}
 }
@@ -151,7 +151,6 @@ func (c ParallelCoordinator) CollectBundle(ctx context.Context, bundleID string,
 			for _, n := range report.Nodes {
 				// any nodes that haven't succeeded and are missing an error (ie haven't already been known as failed)
 				if !n.Succeeded && n.Err == "" {
-					//n.Err = errors.New(msg)
 					n.Err = msg
 				}
 			}

--- a/api/rest/coordinator_test.go
+++ b/api/rest/coordinator_test.go
@@ -130,6 +130,7 @@ func TestCoordinatorCreateAndCollect(t *testing.T) {
 		"192.0.2.2_master/test.txt",
 		"192.0.2.3_public_agent/",
 		"192.0.2.3_public_agent/test.txt",
+		"summaryErrorReport.txt",
 	}
 
 	filenames := []string{}

--- a/api/rest/coordinator_test.go
+++ b/api/rest/coordinator_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -343,4 +344,92 @@ func TestHandlingForCanceledContext(t *testing.T) {
 	for _, s := range results {
 		assert.Contains(t, expected, s)
 	}
+}
+
+func TestCoordinatorCreateAndCollectWithErroredNodes(t *testing.T) {
+	client := new(MockClient)
+	interval := time.Millisecond
+	workDir, err := filepath.Abs("testdata")
+	require.NoError(t, err)
+
+	c := NewParallelCoordinator(client, interval, workDir)
+
+	ctx := context.TODO()
+
+	bundleID := "bundle-0"
+	localBundleID := "bundle-local"
+	numNodes := 3
+
+	node1 := node{IP: net.ParseIP("192.0.2.1"), Role: "agent", baseURL: "http://192.0.2.1"}
+	node2 := node{IP: net.ParseIP("192.0.2.2"), Role: "master", baseURL: "http://192.0.2.2"}
+	node3 := node{IP: net.ParseIP("192.0.2.3"), Role: "public_agent", baseURL: "http://192.0.2.3"}
+
+	testZip1, err := filepath.Abs(filepath.Join("testdata", "192.0.2.1_agent.zip"))
+	require.NoError(t, err)
+	testZip2, err := filepath.Abs(filepath.Join("testdata", "192.0.2.2_master.zip"))
+	require.NoError(t, err)
+
+	testNodes := []struct {
+		n       node
+		zipPath string
+	}{
+		{
+			n:       node1,
+			zipPath: testZip1,
+		},
+		{
+			n:       node2,
+			zipPath: testZip2,
+		},
+	}
+
+	for _, testData := range testNodes {
+		client.On("CreateBundle", ctx, testData.n.baseURL, localBundleID).Return(&Bundle{ID: localBundleID, Status: Started}, nil)
+		client.On("Status", ctx, testData.n.baseURL, localBundleID).Return(&Bundle{ID: localBundleID, Status: Done}, nil)
+		client.On("GetFile", ctx, testData.n.baseURL, localBundleID, testData.zipPath).Return(nil)
+	}
+
+	// For node3, we'll have the calls return errors
+	client.On("CreateBundle", ctx, node3.baseURL, localBundleID).Return(&Bundle{ID: localBundleID, Status: Started}, nil)
+	client.On("Status", ctx, node3.baseURL, localBundleID).Return(nil, &DiagnosticsBundleUnreadableError{id: localBundleID})
+
+	statuses := c.CreateBundle(ctx, localBundleID, []node{node1, node2, node3})
+
+	bundlePath, err := c.CollectBundle(ctx, bundleID, numNodes, statuses)
+	require.NoError(t, err)
+	// ensure that the bundle is placed in the specified directory
+	assert.True(t, filepath.HasPrefix(bundlePath, workDir))
+	defer os.RemoveAll(bundlePath)
+	require.NotEmpty(t, bundlePath)
+
+	zipReader, err := zip.OpenReader(bundlePath)
+	require.NoError(t, err)
+	defer zipReader.Close()
+
+	expectedContents := []string{
+		"192.0.2.1_agent/",
+		"192.0.2.1_agent/test.txt",
+		"192.0.2.2_master/",
+		"192.0.2.2_master/test.txt",
+		"summaryErrorReport.txt",
+	}
+
+	var errorContents string
+	filenames := []string{}
+
+	for _, f := range zipReader.File {
+		filenames = append(filenames, f.Name)
+		if f.Name == "summaryErrorReport.txt" {
+			reader, err := f.Open()
+			require.NoError(t, err)
+			bytes, err := ioutil.ReadAll(reader)
+			require.NoError(t, err)
+
+			errorContents = string(bytes)
+		}
+	}
+	sort.Strings(filenames)
+
+	assert.Equal(t, expectedContents, filenames)
+	assert.Equal(t, "Error getting bundle 192.0.2.3: bundle bundle-local not readable\n", errorContents)
 }

--- a/api/rest/coordinator_test.go
+++ b/api/rest/coordinator_test.go
@@ -22,7 +22,7 @@ func TestCoordinator_CreatorShouldCreateAbundleAndReturnUpdateChan(t *testing.T)
 	interval := time.Millisecond
 	workDir := os.TempDir()
 
-	c := newParallelCoordinator(client, interval, workDir)
+	c := NewParallelCoordinator(client, interval, workDir)
 
 	ctx := context.TODO()
 
@@ -37,20 +37,20 @@ func TestCoordinator_CreatorShouldCreateAbundleAndReturnUpdateChan(t *testing.T)
 		node3,
 	}
 
-	expected := []bundleStatus{}
+	expected := []BundleStatus{}
 
 	for _, n := range testNodes {
 		client.On("CreateBundle", ctx, n.baseURL, localBundleID).Return(&Bundle{ID: localBundleID, Status: Started}, nil)
 		client.On("Status", ctx, n.baseURL, localBundleID).Return(&Bundle{ID: localBundleID, Status: Done}, nil)
 
 		expected = append(expected,
-			bundleStatus{id: localBundleID, node: n},
-			bundleStatus{id: localBundleID, node: n, done: true},
+			BundleStatus{id: localBundleID, node: n},
+			BundleStatus{id: localBundleID, node: n, done: true},
 		)
 	}
 	s := c.CreateBundle(context.TODO(), localBundleID, testNodes)
 
-	var statuses []bundleStatus
+	var statuses []BundleStatus
 
 	for i := 0; i < 6; i++ {
 		statuses = append(statuses, <-s)
@@ -67,7 +67,7 @@ func TestCoordinatorCreateAndCollect(t *testing.T) {
 	workDir, err := filepath.Abs("testdata")
 	require.NoError(t, err)
 
-	c := newParallelCoordinator(client, interval, workDir)
+	c := NewParallelCoordinator(client, interval, workDir)
 
 	ctx := context.TODO()
 
@@ -169,7 +169,7 @@ func TestHandlingForBundleUpdateInProgress(t *testing.T) {
 
 	localBundleID := "bundle-0"
 
-	c := newParallelCoordinator(client, interval, workDir)
+	c := NewParallelCoordinator(client, interval, workDir)
 	ctx := context.TODO()
 
 	n := node{IP: net.ParseIP("127.0.0.1"), Role: "master", baseURL: "http://127.0.0.1"}
@@ -182,7 +182,7 @@ func TestHandlingForBundleUpdateInProgress(t *testing.T) {
 
 	statuses := c.CreateBundle(ctx, localBundleID, []node{n})
 
-	expected := []bundleStatus{
+	expected := []BundleStatus{
 		{
 			id:   localBundleID,
 			node: n,
@@ -200,7 +200,7 @@ func TestHandlingForBundleUpdateInProgress(t *testing.T) {
 		},
 	}
 
-	results := []bundleStatus{}
+	results := []BundleStatus{}
 
 	for i := 0; i < len(expected); i++ {
 		results = append(results, <-statuses)
@@ -219,7 +219,7 @@ func TestErrorHandlingFromClientCreateBundle(t *testing.T) {
 
 	localBundleID := "bundle-0"
 
-	c := newParallelCoordinator(client, interval, workDir)
+	c := NewParallelCoordinator(client, interval, workDir)
 	ctx := context.TODO()
 	n := node{IP: net.ParseIP("127.0.0.1"), Role: "master", baseURL: "http://127.0.0.1"}
 
@@ -228,7 +228,7 @@ func TestErrorHandlingFromClientCreateBundle(t *testing.T) {
 
 	s := c.CreateBundle(ctx, localBundleID, []node{n})
 
-	expected := bundleStatus{
+	expected := BundleStatus{
 		id:   localBundleID,
 		node: n,
 		done: true,
@@ -247,7 +247,7 @@ func TestErrorHandlingFromClientStatus(t *testing.T) {
 
 	localBundleID := "bundle-0"
 
-	c := newParallelCoordinator(client, interval, workDir)
+	c := NewParallelCoordinator(client, interval, workDir)
 	ctx := context.TODO()
 
 	n := node{IP: net.ParseIP("127.0.0.1"), Role: "master", baseURL: "http://127.0.0.1"}
@@ -262,7 +262,7 @@ func TestErrorHandlingFromClientStatus(t *testing.T) {
 
 	statuses := c.CreateBundle(ctx, localBundleID, []node{n})
 
-	expected := []bundleStatus{
+	expected := []BundleStatus{
 		{
 			id:   localBundleID,
 			node: n,
@@ -281,7 +281,7 @@ func TestErrorHandlingFromClientStatus(t *testing.T) {
 		},
 	}
 
-	results := []bundleStatus{}
+	results := []BundleStatus{}
 
 	for i := 0; i < len(expected); i++ {
 		results = append(results, <-statuses)
@@ -300,7 +300,7 @@ func TestHandlingForCanceledContext(t *testing.T) {
 
 	localBundleID := "bundle-0"
 
-	c := newParallelCoordinator(client, interval, workDir)
+	c := NewParallelCoordinator(client, interval, workDir)
 	ctx := context.TODO()
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
@@ -315,7 +315,7 @@ func TestHandlingForCanceledContext(t *testing.T) {
 
 	statuses := c.CreateBundle(ctx, localBundleID, []node{n})
 
-	results := []bundleStatus{}
+	results := []BundleStatus{}
 
 	for s := range statuses {
 		results = append(results, s)
@@ -324,7 +324,7 @@ func TestHandlingForCanceledContext(t *testing.T) {
 		}
 	}
 
-	expected := []bundleStatus{
+	expected := []BundleStatus{
 		{
 			id:   localBundleID,
 			node: n,

--- a/api/rest/mock_tools_test.go
+++ b/api/rest/mock_tools_test.go
@@ -1,0 +1,82 @@
+package rest
+
+import (
+	"time"
+
+	"github.com/dcos/dcos-diagnostics/dcos"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockedTools struct {
+	mock.Mock
+}
+
+func (m *MockedTools) InitializeUnitControllerConnection() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockedTools) CloseUnitControllerConnection() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockedTools) GetUnitProperties(s string) (map[string]interface{}, error) {
+	args := m.Called(s)
+	return args.Get(0).(map[string]interface{}), args.Error(1)
+}
+
+func (m *MockedTools) DetectIP() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockedTools) GetHostname() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockedTools) GetNodeRole() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockedTools) GetUnitNames() ([]string, error) {
+	args := m.Called()
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockedTools) GetJournalOutput(string) (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockedTools) GetMesosNodeID() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockedTools) Get(s string, t time.Duration) ([]byte, int, error) {
+	args := m.Called(s, t)
+	return args.Get(0).([]byte), args.Int(1), args.Error(2)
+}
+
+func (m *MockedTools) Post(s string, t time.Duration) ([]byte, int, error) {
+	args := m.Called(s, t)
+	return args.Get(0).([]byte), args.Int(1), args.Error(2)
+}
+
+func (m *MockedTools) GetMasterNodes() ([]dcos.Node, error) {
+	args := m.Called()
+	return args.Get(0).([]dcos.Node), args.Error(1)
+}
+
+func (m *MockedTools) GetAgentNodes() ([]dcos.Node, error) {
+	args := m.Called()
+	return args.Get(0).([]dcos.Node), args.Error(1)
+}
+
+func (m *MockedTools) GetTimestamp() time.Time {
+	args := m.Called()
+	return args.Get(0).(time.Time)
+}

--- a/api/router.go
+++ b/api/router.go
@@ -18,13 +18,22 @@ import (
 const baseRoute string = "/system/health/v1"
 
 // Endpoint for listing all local bundles
-const bundlesEndpoint = baseRoute + "/node/diagnostics"
+const nodeBundlesEndpoint = baseRoute + "/node/diagnostics"
 
 // CRUD endpoint for diagnostics bundle files
-const bundleEndpoint = bundlesEndpoint + "/{id}"
+const nodeBundleEndpoint = nodeBundlesEndpoint + "/{id}"
 
 // Endpoint to download bundle file
-const bundleFileEndpoint = bundleEndpoint + "/file"
+const nodeBundleFileEndpoint = nodeBundleEndpoint + "/file"
+
+// Endpoint for listing all cluster bundles
+const clusterBundlesEndpoint = baseRoute + "/diagnostics"
+
+// CRUD endpoint for cluster-level diagnostics bundles
+const clusterBundleEndpoint = clusterBundlesEndpoint + "/{id}"
+
+// Endpoint to download cluster bundle file
+const clusterBundleFileEndpoint = clusterBundleEndpoint + "/file"
 
 type routeHandler struct {
 	url                 string
@@ -99,6 +108,7 @@ func getRoutes(dt *Dt) []routeHandler {
 	}
 
 	bh := dt.BundleHandler
+	cbh := dt.ClusterBundleHandler
 
 	routes := []routeHandler{
 		{
@@ -193,29 +203,56 @@ func getRoutes(dt *Dt) []routeHandler {
 		},
 		//---------------------------------------------------------------------
 		// 					V2 REST API for bundles CRUD
+		//---- Node level API
 		{
-			url:     bundleEndpoint,
+			url:     nodeBundleEndpoint,
 			handler: bh.Create,
 			methods: []string{"PUT"},
 		},
 		{
-			url:     bundleEndpoint,
+			url:     nodeBundleEndpoint,
 			handler: bh.Delete,
 			methods: []string{"DELETE"},
 		},
 		{
-			url:     bundlesEndpoint,
+			url:     nodeBundlesEndpoint,
 			handler: bh.List,
 			methods: []string{"GET"},
 		},
 		{
-			url:     bundleEndpoint,
+			url:     nodeBundleEndpoint,
 			handler: bh.Get,
 			methods: []string{"GET"},
 		},
 		{
-			url:     bundleFileEndpoint,
+			url:     nodeBundleFileEndpoint,
 			handler: bh.GetFile,
+			methods: []string{"GET"},
+		},
+		//---- Cluster level API
+		{
+			url:     clusterBundleEndpoint,
+			handler: cbh.Create,
+			methods: []string{"PUT"},
+		},
+		{
+			url:     clusterBundleEndpoint,
+			handler: cbh.Delete,
+			methods: []string{"DELETE"},
+		},
+		{
+			url:     clusterBundlesEndpoint,
+			handler: cbh.List,
+			methods: []string{"GET"},
+		},
+		{
+			url:     clusterBundleEndpoint,
+			handler: cbh.Status,
+			methods: []string{"GET"},
+		},
+		{
+			url:     clusterBundleFileEndpoint,
+			handler: cbh.Download,
 			methods: []string{"GET"},
 		},
 		//---------------------------------------------------------------------

--- a/api/structures.go
+++ b/api/structures.go
@@ -71,14 +71,15 @@ type NodeResponseFieldsWithErrorStruct struct {
 // Dt is a struct of dependencies used in dcos-diagnostics code. There are 2 implementations, the one runs on a real system and
 // the one used for testing.
 type Dt struct {
-	Cfg               *config.Config
-	DtDCOSTools       dcos.Tooler
-	DtDiagnosticsJob  *DiagnosticsJob
-	BundleHandler     rest.BundleHandler
-	RunPullerChan     chan bool
-	RunPullerDoneChan chan bool
-	SystemdUnits      *SystemdUnits
-	MR                *MonitoringResponse
+	Cfg                  *config.Config
+	DtDCOSTools          dcos.Tooler
+	DtDiagnosticsJob     *DiagnosticsJob
+	BundleHandler        rest.BundleHandler
+	ClusterBundleHandler *rest.ClusterBundleHandler
+	RunPullerChan        chan bool
+	RunPullerDoneChan    chan bool
+	SystemdUnits         *SystemdUnits
+	MR                   *MonitoringResponse
 }
 
 type bundle struct {

--- a/dcos/url_builder.go
+++ b/dcos/url_builder.go
@@ -1,0 +1,60 @@
+package dcos
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/dcos/dcos-diagnostics/util"
+)
+
+// NodeURLBuilder is an interface to define how to map from a node's IP and role
+// to a URL to reach the node's HTTP API
+type NodeURLBuilder interface {
+	BaseURL(ip net.IP, role string) (string, error)
+}
+
+// URLBuilder implements NodeURLBuilder mapping agent and master roles to their
+// configured ports and handling if the cluster requires TLS
+type URLBuilder struct {
+	agentPort  int
+	masterPort int
+	forceTLS   bool
+}
+
+// NewURLBuilder constructs a NodeURLBuilder
+func NewURLBuilder(agentPort int, masterPort int, forceTLS bool) URLBuilder {
+	return URLBuilder{
+		agentPort:  agentPort,
+		masterPort: masterPort,
+		forceTLS:   forceTLS,
+	}
+}
+
+// BaseURL will return the base URL for a node given its role and whether the
+// cluster is configured to require TLS.
+func (n *URLBuilder) BaseURL(ip net.IP, role string) (string, error) {
+	port, err := n.port(role)
+	if err != nil {
+		return "", err
+	}
+	url := fmt.Sprintf("http://%s:%d", ip, port)
+	fullURL, err := util.UseTLSScheme(url, n.forceTLS)
+	if err != nil {
+		return "", err
+	}
+
+	return fullURL, nil
+}
+
+func (n *URLBuilder) port(role string) (int, error) {
+	switch role {
+	case AgentRole:
+		fallthrough
+	case AgentPublicRole:
+		return n.agentPort, nil
+	case MasterRole:
+		return n.masterPort, nil
+	default:
+		return 0, fmt.Errorf("incorrect role given %s", role)
+	}
+}

--- a/dcos/url_builder_test.go
+++ b/dcos/url_builder_test.go
@@ -1,0 +1,62 @@
+package dcos
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgentNoTLS(t *testing.T) {
+	builder := NewURLBuilder(8080, 8081, false)
+	ip := net.IPv4(127, 0, 0, 1)
+
+	url, err := builder.BaseURL(ip, AgentRole)
+	assert.NoError(t, err, "")
+	assert.Equal(t, "http://127.0.0.1:8080", url)
+}
+
+func TestMasterNoTLS(t *testing.T) {
+	builder := NewURLBuilder(8080, 8081, false)
+	ip := net.IPv4(127, 0, 0, 1)
+
+	url, err := builder.BaseURL(ip, MasterRole)
+	assert.NoError(t, err, "")
+	assert.Equal(t, "http://127.0.0.1:8081", url)
+}
+
+func TestAgentTLS(t *testing.T) {
+	builder := NewURLBuilder(8080, 8081, true)
+	ip := net.IPv4(127, 0, 0, 1)
+
+	url, err := builder.BaseURL(ip, AgentRole)
+	assert.NoError(t, err, "")
+	assert.Equal(t, "https://127.0.0.1:8080", url)
+}
+
+func TestMasterTLS(t *testing.T) {
+	builder := NewURLBuilder(8080, 8081, true)
+	ip := net.IPv4(127, 0, 0, 1)
+
+	url, err := builder.BaseURL(ip, MasterRole)
+	assert.NoError(t, err, "")
+	assert.Equal(t, "https://127.0.0.1:8081", url)
+}
+
+func TestPublicAgent(t *testing.T) {
+	builder := NewURLBuilder(8080, 8081, false)
+	ip := net.IPv4(127, 0, 0, 1)
+
+	url, err := builder.BaseURL(ip, AgentPublicRole)
+	assert.NoError(t, err)
+	assert.Equal(t, "http://127.0.0.1:8080", url)
+}
+
+func TestInvalidRole(t *testing.T) {
+	builder := NewURLBuilder(8080, 8081, false)
+	ip := net.IPv4(127, 0, 0, 1)
+
+	url, err := builder.BaseURL(ip, "not_a_role")
+	assert.Error(t, err)
+	assert.Empty(t, url)
+}

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
This adds a JSON file with information about whether the node bundles succeeded and has the error message if they didn't.

Related ticket: DCOS_OSS-5303 (this'll be a link when Jira comes back up).

This builds off of https://github.com/dcos/dcos-diagnostics/pull/131 so shouldn't be merged until that's merged.