### PR TITLE
Allow configuration of `detect_ip` script

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -158,6 +158,9 @@ func getNodeInfo(tr http.RoundTripper) (nodeutil.NodeInfo, error) {
 	if defaultConfig.FlagForceTLS {
 		options = append(options, nodeutil.OptionMesosStateURL(defaultStateURL.String()))
 	}
+	if defaultConfig.FlagIPDiscoveryCommandLocation != "" {
+		options = append(options, nodeutil.OptionDetectIP(defaultConfig.FlagIPDiscoveryCommandLocation))
+	}
 	return nodeutil.NewNodeInfo(util.NewHTTPClient(defaultConfig.GetHTTPTimeout(), tr), defaultConfig.FlagRole, options...)
 }
 

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func Test_getNodeInfo(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	node, err := getNodeInfo(nil)
+	assert.Nil(t, node)
+	assert.EqualError(t, err, "Role paramter is invalid or empty. Got ")
+
+	defaultConfig.FlagRole = "master"
+	node, err = getNodeInfo(nil)
+	assert.NoError(t, err)
+
+	ip, err := node.DetectIP()
+	assert.Empty(t, ip)
+	assert.EqualError(t, err, "stat /opt/mesosphere/bin/detect_ip: no such file or directory")
+
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "detect-ip.")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.Write([]byte(`echo 192.0.2.1`))
+	require.NoError(t, err)
+
+	oldValue := defaultConfig.FlagIPDiscoveryCommandLocation
+	defaultConfig.FlagIPDiscoveryCommandLocation = tmpFile.Name()
+	defer func() {defaultConfig.FlagIPDiscoveryCommandLocation = oldValue }()
+
+	node, err = getNodeInfo(nil)
+	assert.NoError(t, err)
+	ip, err = node.DetectIP()
+	assert.NoError(t, err)
+	assert.Equal(t, "192.0.2.1", ip.String())
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,6 +111,8 @@ func init() {
 		defaultConfig.FlagIAMConfig, "A path to identity and access management config")
 	daemonCmd.PersistentFlags().StringVar(&defaultConfig.FlagHostname, "hostname",
 		defaultConfig.FlagHostname, "A host name (by default it uses system hostname)")
+	daemonCmd.PersistentFlags().StringVar(&defaultConfig.FlagIPDiscoveryCommandLocation, "ip-discovery-command-location",
+		defaultConfig.FlagIPDiscoveryCommandLocation, "A command used to get local IP address")
 	// diagnostics job flags
 	daemonCmd.PersistentFlags().StringVar(&defaultConfig.FlagDiagnosticsBundleDir,
 		"diagnostics-bundle-dir", diagnosticsBundleDir, "Set a path to store diagnostic bundles")

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	FlagRole                       string `mapstructure:"role"`
 	FlagIAMConfig                  string `mapstructure:"iam-config"`
 	FlagHostname                   string `mapstructure:"hostname"`
+	FlagIPDiscoveryCommandLocation string `mapstructure:"ip-discovery-command-location"`
 
 	// diagnostics job flags
 	FlagDiagnosticsBundleDir                     string   `mapstructure:"diagnostics-bundle-dir"`


### PR DESCRIPTION
Add `--ip-discovery-command` config options that accepts path to `detect_ip` script.

Fixes: https://jira.mesosphere.com/browse/DCOS_OSS-5384