### PR TITLE
Use http.ServeFile instead of creating it by hand

### DIFF
--- a/api/rest/cluster_bundle_handler.go
+++ b/api/rest/cluster_bundle_handler.go
@@ -314,14 +314,7 @@ func (c *ClusterBundleHandler) Download(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	data, err := ioutil.ReadFile(bundleFilename)
-	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, fmt.Errorf("unable to read downloaded bundle file: %s", err))
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	w.Write(data)
+	http.ServeFile(w, r, bundleFilename)
 }
 
 func (c *ClusterBundleHandler) getMasterNodes() ([]node, error) {


### PR DESCRIPTION
In
https://github.com/dcos/dcos-diagnostics/blob/b5f70d473bc00b613729d940dfba98f7d1395182/api/rest/bundle_handler.go#L230
we use http.ServeFile that is handling lots of config specific seetings
for us. We should do the same for cluster handler.