### PR TITLE
Add content type and content disposition headers to file response

### DIFF
--- a/api/rest/bundle_handler.go
+++ b/api/rest/bundle_handler.go
@@ -226,7 +226,8 @@ func (h BundleHandler) Get(w http.ResponseWriter, r *http.Request) {
 func (h BundleHandler) GetFile(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
-
+	w.Header().Add("Content-Type", "application/zip, application/octet-stream")
+	w.Header().Add("Content-disposition", fmt.Sprintf("attachment; filename=%s.zip", id))
 	http.ServeFile(w, r, filepath.Join(h.workDir, id, dataFileName))
 }
 

--- a/api/rest/cluster_bundle_handler.go
+++ b/api/rest/cluster_bundle_handler.go
@@ -313,7 +313,8 @@ func (c *ClusterBundleHandler) Download(w http.ResponseWriter, r *http.Request) 
 		writeJSONError(w, http.StatusInternalServerError, fmt.Errorf("error downloading bundle: %s", err))
 		return
 	}
-
+	w.Header().Add("Content-Type", "application/zip, application/octet-stream")
+	w.Header().Add("Content-disposition", fmt.Sprintf("attachment; filename=%s.zip", id))
 	http.ServeFile(w, r, bundleFilename)
 }
 


### PR DESCRIPTION
To make it easier to operate on diagnostics API with browser
add header that will tell how to handle content.

See:
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type