### PR TITLE
DCOS_OSS-5454 fix broken response body

### DIFF
--- a/api/rest/bundle_handler.go
+++ b/api/rest/bundle_handler.go
@@ -234,6 +234,7 @@ func (h BundleHandler) List(w http.ResponseWriter, r *http.Request) {
 	ids, err := ioutil.ReadDir(h.workDir)
 	if err != nil {
 		writeJSONError(w, http.StatusInsufficientStorage, fmt.Errorf("could not read work dir: %s", err))
+		return
 	}
 
 	bundles := make([]Bundle, 0, len(ids))

--- a/api/rest/bundle_handler_test.go
+++ b/api/rest/bundle_handler_test.go
@@ -171,6 +171,27 @@ func TestIfListShowsStatusWithoutAFile(t *testing.T) {
 	}]`, rr.Body.String())
 }
 
+func TestIfListFailsWithoutBundleDir(t *testing.T) {
+	t.Parallel()
+
+	bh := NewBundleHandler("/this/dir/does/not/exist", nil, time.Millisecond)
+
+	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
+	require.NoError(t, err)
+
+	handler := http.HandlerFunc(bh.List)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInsufficientStorage, rr.Code)
+
+	assert.JSONEq(t, `{
+		"code": 507,
+		"error": "could not read work dir: open /this/dir/does/not/exist: no such file or directory"
+	}`, rr.Body.String())
+}
+
 func TestIfShowsStatusWithoutAFileButStatusDoneShouldChangeStatusToUnknown(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
BundleHandler.List should return after writing the error to the
response stream.