### PR TITLE
Fix race on writing to bundle state file

### DIFF
--- a/api/rest/bundle_handler.go
+++ b/api/rest/bundle_handler.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dcos/dcos-diagnostics/collector"
@@ -57,6 +58,7 @@ func (realClock) Now() time.Time { return time.Now() }
 
 func NewBundleHandler(workDir string, collectors []collector.Collector, timeout time.Duration) BundleHandler {
 	return BundleHandler{
+		mutex:                 &sync.RWMutex{},
 		clock:                 realClock{},
 		workDir:               workDir,
 		collectors:            collectors,
@@ -67,6 +69,7 @@ func NewBundleHandler(workDir string, collectors []collector.Collector, timeout 
 // BundleHandler is a struct that collects all functions
 // responsible for diagnostics bundle lifecycle
 type BundleHandler struct {
+	mutex                 *sync.RWMutex // used to synchronize access to state file
 	clock                 Clock
 	workDir               string                // location where bundles are generated and stored
 	collectors            []collector.Collector // information what should be in the bundle
@@ -95,16 +98,13 @@ func (h BundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stateFilePath := filepath.Join(h.workDir, id, stateFileName)
-
 	bundle := Bundle{
 		ID:      id,
 		Started: h.clock.Now(),
 		Status:  Started,
 	}
 
-	bundleStatus := jsonMarshal(bundle)
-	err = ioutil.WriteFile(stateFilePath, bundleStatus, filePerm)
+	bundleStatus, err := h.writeStateFile(bundle)
 	if err != nil {
 		writeJSONError(w, http.StatusInsufficientStorage, fmt.Errorf("could not update state file %s: %s", id, err))
 		return
@@ -128,7 +128,7 @@ func (h BundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 		case bundle.Errors = <-done:
 			bundle.Status = Done
 			bundle.Stopped = h.clock.Now()
-			if e := ioutil.WriteFile(stateFilePath, jsonMarshal(bundle), filePerm); e != nil {
+			if _, e := h.writeStateFile(bundle); e != nil {
 				logrus.WithError(e).Errorf("Could not update state file %s", id)
 			}
 		}
@@ -262,8 +262,7 @@ func (h BundleHandler) getBundleState(id string) (Bundle, error) {
 		Status: Unknown,
 	}
 
-	stateFilePath := filepath.Join(h.workDir, id, stateFileName)
-	rawState, err := ioutil.ReadFile(stateFilePath)
+	rawState, err := h.readStateFile(bundle)
 	if err != nil {
 		return bundle, fmt.Errorf("could not read state file for bundle %s: %s", id, err)
 	}
@@ -282,16 +281,7 @@ func (h BundleHandler) getBundleState(id string) (Bundle, error) {
 		bundle.Status = Unknown
 		return bundle, fmt.Errorf("could not stat data file %s: %s", id, err)
 	}
-
-	if bundle.Size != dataFileStat.Size() {
-		bundle.Size = dataFileStat.Size()
-		// Update status files
-		bundleStatus := jsonMarshal(bundle)
-		err = ioutil.WriteFile(stateFilePath, bundleStatus, filePerm)
-		if err != nil {
-			return bundle, fmt.Errorf("could not update state file %s: %s", id, err)
-		}
-	}
+	bundle.Size = dataFileStat.Size()
 
 	return bundle, nil
 }
@@ -311,7 +301,6 @@ func (h BundleHandler) bundleExists(id string) bool {
 func (h BundleHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
-	stateFilePath := filepath.Join(h.workDir, id, stateFileName)
 
 	if !h.bundleExists(id) {
 		http.NotFound(w, r)
@@ -342,14 +331,29 @@ func (h BundleHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bundle.Status = Deleted
-	newRawState := jsonMarshal(bundle)
-	err = ioutil.WriteFile(stateFilePath, newRawState, filePerm)
+	newRawState, err := h.writeStateFile(bundle)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError,
 			fmt.Errorf("bundle %s was deleted but state could not be updated: %s", id, err))
 		return
 	}
 	write(w, newRawState)
+}
+
+func (h BundleHandler) writeStateFile(bundle Bundle) ([]byte, error) {
+	stateFilePath := filepath.Join(h.workDir, bundle.ID, stateFileName)
+	newRawState := jsonMarshal(bundle)
+	h.mutex.Lock()
+	err := ioutil.WriteFile(stateFilePath, newRawState, filePerm)
+	h.mutex.Unlock()
+	return newRawState, err
+}
+
+func (h BundleHandler) readStateFile(bundle Bundle) ([]byte, error) {
+	stateFilePath := filepath.Join(h.workDir, bundle.ID, stateFileName)
+	h.mutex.RLock()
+	defer h.mutex.RUnlock()
+	return ioutil.ReadFile(stateFilePath)
 }
 
 func writeJSONError(w http.ResponseWriter, code int, e error) {

--- a/api/rest/bundle_handler_test.go
+++ b/api/rest/bundle_handler_test.go
@@ -237,7 +237,7 @@ func TestIfShowsStatusWithoutAFileButStatusDoneShouldChangeStatusToUnknown(t *te
 	}]`, rr.Body.String())
 }
 
-func TestIfShowsStatusWithFileAndUpdatesFileSize(t *testing.T) {
+func TestIfShowsStatusWithFileAndDontUpdatesFileSize(t *testing.T) {
 	t.Parallel()
 
 	workdir, err := ioutil.TempDir("", "work-dir")
@@ -247,12 +247,12 @@ func TestIfShowsStatusWithFileAndUpdatesFileSize(t *testing.T) {
 	err = os.Mkdir(bundleWorkDir, dirPerm)
 	require.NoError(t, err)
 	stateFilePath := filepath.Join(bundleWorkDir, stateFileName)
-	err = ioutil.WriteFile(stateFilePath,
-		[]byte(`{
+	oldState := `{
 		"id": "bundle",
 		"status": "Done",
 		"started_at":"1991-05-21T00:00:00Z",
-		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
+		"stopped_at":"2019-05-21T00:00:00Z" }`
+	err = ioutil.WriteFile(stateFilePath, []byte(oldState), filePerm)
 	require.NoError(t, err)
 	err = ioutil.WriteFile(filepath.Join(bundleWorkDir, dataFileName), []byte(`OK`), filePerm)
 	require.NoError(t, err)
@@ -280,7 +280,7 @@ func TestIfShowsStatusWithFileAndUpdatesFileSize(t *testing.T) {
 	assert.JSONEq(t, "["+expectedState+"]", rr.Body.String())
 
 	newState, err := ioutil.ReadFile(stateFilePath)
-	assert.JSONEq(t, expectedState, string(newState))
+	assert.JSONEq(t, oldState, string(newState))
 }
 
 func TestIfGetShowsStatusWithoutAFileWhenBundleIsDeleted(t *testing.T) {
@@ -826,6 +826,7 @@ func TestIfE2E_(t *testing.T) {
 	})
 
 	t.Run("list bundles", func(t *testing.T) {
+		time.Sleep(10 * time.Millisecond)
 		req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
 		require.NoError(t, err)
 		rr := httptest.NewRecorder()


### PR DESCRIPTION
* Add mutex to synchronize all writes to a file. The mutext is shared for all writes but since API need to support small amount of request it's fine.
* Do not update state file when get state detect file size differs from value stored in a file
* Sleep in E2E test to ensure everything is updated and we do not read previous version of a state file

Fixes: https://jira.mesosphere.com/browse/DCOS_OSS-5331