### PR TITLE
Add workdir initialization to BundleHandler and ClusterBundleHandler

### DIFF
--- a/api/rest/bundle_handler.go
+++ b/api/rest/bundle_handler.go
@@ -57,20 +57,8 @@ type realClock struct{}
 func (realClock) Now() time.Time { return time.Now() }
 
 func NewBundleHandler(workDir string, collectors []collector.Collector, timeout time.Duration) (*BundleHandler, error) {
-	f, err := os.Stat(workDir)
+	err := initializeWorkDir(workDir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			err = os.Mkdir(workDir, dirPerm)
-			if err != nil {
-				logrus.WithError(err).Errorf("workDir does not exist and could not be created %s", workDir)
-				return nil, err
-			}
-		} else {
-			logrus.Errorf("Could not open workDir %s", workDir)
-			return nil, err
-		}
-	} else if f.Mode().IsRegular() {
-		logrus.Errorf("workDir exists but is not a directory: %s", workDir)
 		return nil, err
 	}
 
@@ -401,4 +389,14 @@ func jsonMarshal(v interface{}) []byte {
 		logrus.WithError(err).Fatalf("Could not marshal %v: %s", v, err)
 	}
 	return rawJSON
+}
+
+// initializeWorkDir will create the specified bundle working directory if it doesn't already exist
+// and will do nothing if it does.
+func initializeWorkDir(workDir string) error {
+	err := os.MkdirAll(workDir, dirPerm)
+	if err != nil {
+		return fmt.Errorf("could not create workdir: %s", err)
+	}
+	return nil
 }

--- a/api/rest/bundle_handler.go
+++ b/api/rest/bundle_handler.go
@@ -59,12 +59,9 @@ func (realClock) Now() time.Time { return time.Now() }
 func NewBundleHandler(workDir string, collectors []collector.Collector, timeout time.Duration) (*BundleHandler, error) {
 	f, err := os.Stat(workDir)
 	if err != nil {
-		fmt.Println("error stating workdir")
 		if os.IsNotExist(err) {
-			fmt.Println("workdir does not exist")
 			err = os.Mkdir(workDir, dirPerm)
 			if err != nil {
-				fmt.Println("unable to create")
 				logrus.WithError(err).Errorf("workDir does not exist and could not be created %s", workDir)
 				return nil, err
 			}

--- a/api/rest/bundle_handler_test.go
+++ b/api/rest/bundle_handler_test.go
@@ -846,7 +846,7 @@ func TestIfE2E_(t *testing.T) {
 	})
 }
 
-func TestBundleDirIsCreatedIfNotExists(t *testing.T) {
+func TestBundleHandlerWorkDirIsCreatedIfNotExists(t *testing.T) {
 	t.Parallel()
 
 	workdir, err := ioutil.TempDir("", "work-dir")
@@ -858,6 +858,17 @@ func TestBundleDirIsCreatedIfNotExists(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.DirExists(t, workdir)
+}
+
+func TestBundleHandlerWorkDirInitFailsWhenFileExists(t *testing.T) {
+	t.Parallel()
+
+	// note TempFile and not TempDir
+	workdir, err := ioutil.TempFile("", "work-dir")
+	require.NoError(t, err)
+
+	_, err = NewBundleHandler(workdir.Name(), nil, time.Millisecond)
+	assert.Error(t, err)
 }
 
 // MockClock is a monotonic clock. Every call to Now() adds one hour

--- a/api/rest/bundle_handler_test.go
+++ b/api/rest/bundle_handler_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,7 +11,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -29,23 +27,6 @@ const (
 	bundleFileEndpoint = bundleEndpoint + "/file"
 )
 
-func TestIfReturns507ForNotExistingDir(t *testing.T) {
-	t.Parallel()
-	bh := NewBundleHandler("not existing dir", nil, time.Nanosecond)
-
-	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
-	require.NoError(t, err)
-
-	handler := http.HandlerFunc(bh.List)
-
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	assert.Equal(t, http.StatusInsufficientStorage, rr.Code)
-
-	assert.Contains(t, rr.Body.String(), `{"code":507,"error":"could not read work dir: `)
-}
-
 func TestIfReturnsEmptyListWhenDirIsEmpty(t *testing.T) {
 	t.Parallel()
 
@@ -53,7 +34,8 @@ func TestIfReturnsEmptyListWhenDirIsEmpty(t *testing.T) {
 	defer os.RemoveAll(workdir)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
 	require.NoError(t, err)
@@ -77,7 +59,8 @@ func TestIfReturnsEmptyListWhenDirIsEmptyContainsNoDirs(t *testing.T) {
 	_, err = ioutil.TempFile(workdir, "")
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
 	require.NoError(t, err)
@@ -103,7 +86,8 @@ func TestIfDirsAsBundlesIdsWithStatusUnknown(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
 	require.NoError(t, err)
@@ -153,7 +137,8 @@ func TestIfListShowsStatusWithoutAFile(t *testing.T) {
 		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
 	require.NoError(t, err)
@@ -173,10 +158,16 @@ func TestIfListShowsStatusWithoutAFile(t *testing.T) {
 	}]`, rr.Body.String())
 }
 
-func TestIfListFailsWithoutBundleDir(t *testing.T) {
+func TestIfListWorksWithoutBundleDir(t *testing.T) {
 	t.Parallel()
 
-	bh := NewBundleHandler("/this/dir/does/not/exist", nil, time.Millisecond)
+	workdir, err := ioutil.TempDir("", "work-dir")
+	require.NoError(t, err)
+	err = os.RemoveAll(workdir)
+	require.NoError(t, err)
+
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
 	require.NoError(t, err)
@@ -186,18 +177,8 @@ func TestIfListFailsWithoutBundleDir(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusInsufficientStorage, rr.Code)
-
-	type Response struct {
-		Code  int
-		Error string
-	}
-	var resp Response
-	err = json.Unmarshal(rr.Body.Bytes(), &resp)
-	assert.NoError(t, err)
-
-	assert.Equal(t, resp.Code, 507)
-	assert.True(t, strings.HasPrefix(resp.Error, "could not read work dir: open /this/dir/does/not/exist: "))
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.EqualValues(t, []byte(`[]`), rr.Body.Bytes())
 }
 
 func TestIfShowsStatusWithoutAFileButStatusDoneShouldChangeStatusToUnknown(t *testing.T) {
@@ -217,7 +198,8 @@ func TestIfShowsStatusWithoutAFileButStatusDoneShouldChangeStatusToUnknown(t *te
 		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
 	require.NoError(t, err)
@@ -257,7 +239,8 @@ func TestIfShowsStatusWithFileAndUpdatesFileSize(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(bundleWorkDir, dataFileName), []byte(`OK`), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
 	require.NoError(t, err)
@@ -300,7 +283,8 @@ func TestIfGetShowsStatusWithoutAFileWhenBundleIsDeleted(t *testing.T) {
 		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle", nil)
 	require.NoError(t, err)
@@ -337,7 +321,8 @@ func TestIfGetShowsStatusWithoutAFileWhenBundleIsDone(t *testing.T) {
 		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle", nil)
 	require.NoError(t, err)
@@ -368,7 +353,8 @@ func TestIfGetReturns500WhenBundleStateIsNotJson(t *testing.T) {
 		[]byte(`invalid JSON`), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle-state-not-json", nil)
 	router := mux.NewRouter()
@@ -394,7 +380,12 @@ func TestIfGetReturns500WhenBundleStateIsNotJson(t *testing.T) {
 func TestIfDeleteReturns404WhenNoBundleFound(t *testing.T) {
 	t.Parallel()
 
-	bh := NewBundleHandler("", nil, time.Nanosecond)
+	workdir, err := ioutil.TempDir("", "work-dir")
+	defer os.RemoveAll(workdir)
+	require.NoError(t, err)
+
+	bh, err := NewBundleHandler(workdir, nil, time.Nanosecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/not-existing-bundle", nil)
 	require.NoError(t, err)
@@ -419,7 +410,8 @@ func TestIfDeleteReturns500WhenNoBundleStateFound(t *testing.T) {
 	err = os.Mkdir(bundleWorkDir, dirPerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/not-existing-bundle-state", nil)
 	require.NoError(t, err)
@@ -450,7 +442,8 @@ func TestIfDeleteReturns500WhenBundleStateIsNotJson(t *testing.T) {
 		[]byte(`invalid JSON`), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/bundle-state-not-json", nil)
 	require.NoError(t, err)
@@ -493,7 +486,8 @@ func TestIfDeleteReturns304WhenBundleWasDeletedBefore(t *testing.T) {
 	err = ioutil.WriteFile(stateFilePath, []byte(bundleState), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/deleted-bundle", nil)
 	require.NoError(t, err)
@@ -524,7 +518,8 @@ func TestIfDeleteReturns500WhenBundleFileIsMissing(t *testing.T) {
 		"stopped_at":"2019-05-21T00:00:00Z" }`)), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/missing-data-file", nil)
 	require.NoError(t, err)
@@ -562,7 +557,8 @@ func TestIfDeleteReturns200WhenBundleWasDeleted(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(bundleWorkDir, dataFileName), []byte(`OK`), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/bundle-0", nil)
 	require.NoError(t, err)
@@ -595,7 +591,8 @@ func TestIfGetFileReturnsBundle(t *testing.T) {
 		[]byte(`OK`), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle", nil)
 	require.NoError(t, err)
@@ -617,7 +614,8 @@ func TestIfGetFileReturnsErrorWhenBundleDoesNotExists(t *testing.T) {
 	defer os.RemoveAll(workdir)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle", nil)
 	require.NoError(t, err)
@@ -651,7 +649,8 @@ func TestIfCreateReturns409WhenBundleWithGivenIdAlreadyExists(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(bundleWorkDir, dataFileName), []byte(`OK`), filePerm)
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, bundlesEndpoint+"/bundle-0", nil)
 	require.NoError(t, err)
@@ -675,7 +674,8 @@ func TestIfCreateReturns507WhenCouldNotCreateWorkDir(t *testing.T) {
 	bundleWorkDir := filepath.Join(workdir, "bundle-0")
 	err = ioutil.WriteFile(bundleWorkDir, []byte{}, 0000)
 
-	bh := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, bundlesEndpoint+"/bundle-0", nil)
 	require.NoError(t, err)
@@ -699,7 +699,7 @@ func TestIfE2E_(t *testing.T) {
 	now, err := time.Parse(time.RFC3339, "2015-08-05T08:40:51.620Z")
 	require.NoError(t, err)
 
-	bh := NewBundleHandler(
+	bh, err := NewBundleHandler(
 		workdir,
 		[]collector.Collector{
 			MockCollector{name: "collector-1", err: fmt.Errorf("some error")},
@@ -707,6 +707,7 @@ func TestIfE2E_(t *testing.T) {
 		},
 		time.Second,
 	)
+	require.NoError(t, err)
 	bh.clock = &MockClock{now: now}
 
 	router := mux.NewRouter()
@@ -741,7 +742,8 @@ func TestIfE2E_(t *testing.T) {
 	t.Run("get bundle-0 status", func(t *testing.T) {
 		for { // busy wait for bundle
 			bundle, err := client.Status(context.TODO(), testServer.URL, "bundle-0")
-			require.NoError(t, err)
+			//require.NoError(t, err)
+			assert.NoError(t, err)
 			if bundle.Status == Done {
 				break
 			}
@@ -842,6 +844,20 @@ func TestIfE2E_(t *testing.T) {
 			Errors:  []string{"could not collect collector-1: some error"},
 		}})), rr.Body.String())
 	})
+}
+
+func TestBundleDirIsCreatedIfNotExists(t *testing.T) {
+	t.Parallel()
+
+	workdir, err := ioutil.TempDir("", "work-dir")
+	require.NoError(t, err)
+	err = os.RemoveAll(workdir)
+	require.NoError(t, err)
+
+	_, err = NewBundleHandler(workdir, nil, time.Millisecond)
+	require.NoError(t, err)
+
+	assert.DirExists(t, workdir)
 }
 
 // MockClock is a monotonic clock. Every call to Now() adds one hour

--- a/api/rest/bundle_handler_test.go
+++ b/api/rest/bundle_handler_test.go
@@ -742,8 +742,7 @@ func TestIfE2E_(t *testing.T) {
 	t.Run("get bundle-0 status", func(t *testing.T) {
 		for { // busy wait for bundle
 			bundle, err := client.Status(context.TODO(), testServer.URL, "bundle-0")
-			//require.NoError(t, err)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if bundle.Status == Done {
 				break
 			}

--- a/api/rest/cluster_bundle_handler.go
+++ b/api/rest/cluster_bundle_handler.go
@@ -31,7 +31,26 @@ type ClusterBundleHandler struct {
 }
 
 func NewClusterBundleHandler(c Coordinator, client Client, tools dcos.Tooler, workDir string, timeout time.Duration,
-	urlBuilder dcos.NodeURLBuilder) *ClusterBundleHandler {
+	urlBuilder dcos.NodeURLBuilder) (*ClusterBundleHandler, error) {
+	f, err := os.Stat(workDir)
+	if err != nil {
+		fmt.Println("error stating workdir")
+		if os.IsNotExist(err) {
+			fmt.Println("workdir does not exist")
+			err = os.Mkdir(workDir, dirPerm)
+			if err != nil {
+				fmt.Println("unable to create")
+				logrus.WithError(err).Errorf("workDir does not exist and could not be created %s", workDir)
+				return nil, err
+			}
+		} else {
+			logrus.Errorf("Could not open workDir %s", workDir)
+			return nil, err
+		}
+	} else if f.Mode().IsRegular() {
+		logrus.Errorf("workDir exists but is not a directory: %s", workDir)
+		return nil, err
+	}
 
 	return &ClusterBundleHandler{
 		coord:      c,
@@ -41,7 +60,7 @@ func NewClusterBundleHandler(c Coordinator, client Client, tools dcos.Tooler, wo
 		tools:      tools,
 		clock:      &realClock{},
 		urlBuilder: urlBuilder,
-	}
+	}, nil
 }
 
 // Create will send the initial creation request for the bundle to all nodes. The created

--- a/api/rest/cluster_bundle_handler.go
+++ b/api/rest/cluster_bundle_handler.go
@@ -32,23 +32,8 @@ type ClusterBundleHandler struct {
 
 func NewClusterBundleHandler(c Coordinator, client Client, tools dcos.Tooler, workDir string, timeout time.Duration,
 	urlBuilder dcos.NodeURLBuilder) (*ClusterBundleHandler, error) {
-	f, err := os.Stat(workDir)
+	err := initializeWorkDir(workDir)
 	if err != nil {
-		fmt.Println("error stating workdir")
-		if os.IsNotExist(err) {
-			fmt.Println("workdir does not exist")
-			err = os.Mkdir(workDir, dirPerm)
-			if err != nil {
-				fmt.Println("unable to create")
-				logrus.WithError(err).Errorf("workDir does not exist and could not be created %s", workDir)
-				return nil, err
-			}
-		} else {
-			logrus.Errorf("Could not open workDir %s", workDir)
-			return nil, err
-		}
-	} else if f.Mode().IsRegular() {
-		logrus.Errorf("workDir exists but is not a directory: %s", workDir)
 		return nil, err
 	}
 

--- a/api/rest/cluster_bundle_handler_test.go
+++ b/api/rest/cluster_bundle_handler_test.go
@@ -871,7 +871,7 @@ func TestRemoteBundleCreation(t *testing.T) {
 	})
 }
 
-func TestWorkDirIsCreatedIfNotExists(t *testing.T) {
+func TestClusterBundleHandlerWorkDirIsCreatedIfNotExists(t *testing.T) {
 	t.Parallel()
 
 	workdir, err := ioutil.TempDir("", "work-dir")
@@ -887,6 +887,21 @@ func TestWorkDirIsCreatedIfNotExists(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.DirExists(t, workdir)
+}
+
+func TestClusterBundleHandlerWorkDirInitFailsWhenFileExists(t *testing.T) {
+	t.Parallel()
+
+	// note TempFile and not TempDir
+	workdir, err := ioutil.TempFile("", "work-dir")
+	require.NoError(t, err)
+
+	coord := mockCoordinator{}
+	client := &MockClient{}
+	tools := &MockedTools{}
+	urlBuilder := MockURLBuilder{}
+	_, err = NewClusterBundleHandler(coord, client, tools, workdir.Name(), time.Millisecond, urlBuilder)
+	assert.Error(t, err)
 }
 
 type mockCoordinator struct{}

--- a/api/rest/cluster_bundle_handler_test.go
+++ b/api/rest/cluster_bundle_handler_test.go
@@ -871,6 +871,24 @@ func TestRemoteBundleCreation(t *testing.T) {
 	})
 }
 
+func TestWorkDirIsCreatedIfNotExists(t *testing.T) {
+	t.Parallel()
+
+	workdir, err := ioutil.TempDir("", "work-dir")
+	require.NoError(t, err)
+	err = os.RemoveAll(workdir)
+	require.NoError(t, err)
+
+	coord := mockCoordinator{}
+	client := &MockClient{}
+	tools := &MockedTools{}
+	urlBuilder := MockURLBuilder{}
+	_, err = NewClusterBundleHandler(coord, client, tools, workdir, time.Millisecond, urlBuilder)
+	require.NoError(t, err)
+
+	assert.DirExists(t, workdir)
+}
+
 type mockCoordinator struct{}
 
 func (c mockCoordinator) CreateBundle(ctx context.Context, id string, nodes []node) <-chan BundleStatus {

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -99,7 +99,10 @@ func startDiagnosticsDaemon() {
 	}
 
 	bundleTimeout := time.Minute * time.Duration(defaultConfig.FlagDiagnosticsJobTimeoutMinutes)
-	bundleHandler := rest.NewBundleHandler(defaultConfig.FlagDiagnosticsBundleDir, collectors, bundleTimeout)
+	bundleHandler, err := rest.NewBundleHandler(defaultConfig.FlagDiagnosticsBundleDir, collectors, bundleTimeout)
+	if err != nil {
+		logrus.WithError(err).Fatal("bundleHandler could not be created")
+	}
 	diagClient := rest.NewDiagnosticsClient(client)
 	coord := rest.NewParallelCoordinator(diagClient, time.Minute, defaultConfig.FlagDiagnosticsBundleDir)
 	urlBuilder := diagDcos.NewURLBuilder(defaultConfig.FlagAgentPort, defaultConfig.FlagMasterPort, defaultConfig.FlagForceTLS)
@@ -111,7 +114,7 @@ func startDiagnosticsDaemon() {
 		Cfg:                  defaultConfig,
 		DtDCOSTools:          DCOSTools,
 		DtDiagnosticsJob:     diagnosticsJob,
-		BundleHandler:        bundleHandler,
+		BundleHandler:        *bundleHandler,
 		ClusterBundleHandler: clusterBundleHandler,
 		RunPullerChan:        make(chan bool),
 		RunPullerDoneChan:    make(chan bool),

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -101,13 +101,16 @@ func startDiagnosticsDaemon() {
 	bundleTimeout := time.Minute * time.Duration(defaultConfig.FlagDiagnosticsJobTimeoutMinutes)
 	bundleHandler, err := rest.NewBundleHandler(defaultConfig.FlagDiagnosticsBundleDir, collectors, bundleTimeout)
 	if err != nil {
-		logrus.WithError(err).Fatal("bundleHandler could not be created")
+		logrus.WithError(err).Fatal("BundleHandler could not be created")
 	}
 	diagClient := rest.NewDiagnosticsClient(client)
 	coord := rest.NewParallelCoordinator(diagClient, time.Minute, defaultConfig.FlagDiagnosticsBundleDir)
 	urlBuilder := diagDcos.NewURLBuilder(defaultConfig.FlagAgentPort, defaultConfig.FlagMasterPort, defaultConfig.FlagForceTLS)
-	clusterBundleHandler := rest.NewClusterBundleHandler(coord, diagClient, DCOSTools, defaultConfig.FlagDiagnosticsBundleDir,
+	clusterBundleHandler, err := rest.NewClusterBundleHandler(coord, diagClient, DCOSTools, defaultConfig.FlagDiagnosticsBundleDir,
 		bundleTimeout, &urlBuilder)
+	if err != nil {
+		logrus.WithError(err).Fatal("ClusterBundleHandler could not be created")
+	}
 
 	// Inject dependencies used for running dcos-diagnostics.
 	dt := &api.Dt{


### PR DESCRIPTION
Addresses https://jira.mesosphere.com/browse/DCOS_OSS-5454 by having `NewBundleHandler` and `NewClusterBundleHandler` initialize `workdir` if it doesn't exist.