### PR TITLE
Change `Type` to Local and Remote and make it part of Bundle metadata

### DIFF
--- a/api/rest/bundle_handler.go
+++ b/api/rest/bundle_handler.go
@@ -36,6 +36,7 @@ const (
 
 type Bundle struct {
 	ID      string    `json:"id,omitempty"`
+	Type    Type      `json:"type"`
 	Size    int64     `json:"size,omitempty"` // length in bytes for regular files; 0 when Canceled or Deleted
 	Status  Status    `json:"status"`
 	Started time.Time `json:"started_at,omitempty"`

--- a/api/rest/bundle_handler_test.go
+++ b/api/rest/bundle_handler_test.go
@@ -118,18 +118,21 @@ func TestIfDirsAsBundlesIdsWithStatusUnknown(t *testing.T) {
 	assert.JSONEq(t, `[
 	{
 	    "id":"bundle-0",
+		"type": "Local",
 		"status": "Unknown",
 	    "started_at":"0001-01-01T00:00:00Z",
 	    "stopped_at":"0001-01-01T00:00:00Z"
 	},
 	{
     	"id":"bundle-1",
+		"type": "Local",
 		"status": "Unknown",
 	    "started_at":"0001-01-01T00:00:00Z",
 	    "stopped_at":"0001-01-01T00:00:00Z"
   	},
   	{
 	    "id":"bundle-2",
+		"type": "Local",
 		"status": "Unknown",
 	    "started_at":"0001-01-01T00:00:00Z",
 	    "stopped_at":"0001-01-01T00:00:00Z"
@@ -148,6 +151,7 @@ func TestIfListShowsStatusWithoutAFile(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(bundleWorkDir, stateFileName),
 		[]byte(`{
 		"id": "bundle",
+		"type": "Local",
 		"status": "Deleted",
 		"started_at":"1991-05-21T00:00:00Z",
 		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
@@ -167,6 +171,7 @@ func TestIfListShowsStatusWithoutAFile(t *testing.T) {
 
 	assert.JSONEq(t, `[{
 		"id": "bundle",
+		"type": "Local",
 		"status": "Deleted",
 		"started_at":"1991-05-21T00:00:00Z",
 		"stopped_at":"2019-05-21T00:00:00Z"
@@ -231,6 +236,7 @@ func TestIfShowsStatusWithoutAFileButStatusDoneShouldChangeStatusToUnknown(t *te
 
 	assert.JSONEq(t, `[{
 		"id": "bundle",
+		"type": "Local",
 		"status": "Unknown",
 		"started_at":"1991-05-21T00:00:00Z",
 		"stopped_at":"2019-05-21T00:00:00Z"
@@ -249,6 +255,7 @@ func TestIfShowsStatusWithFileAndDontUpdatesFileSize(t *testing.T) {
 	stateFilePath := filepath.Join(bundleWorkDir, stateFileName)
 	oldState := `{
 		"id": "bundle",
+		"type": "Local",
 		"status": "Done",
 		"started_at":"1991-05-21T00:00:00Z",
 		"stopped_at":"2019-05-21T00:00:00Z" }`
@@ -271,6 +278,7 @@ func TestIfShowsStatusWithFileAndDontUpdatesFileSize(t *testing.T) {
 
 	expectedState := `{
 		"id": "bundle",
+		"type": "Local",
 		"status": "Done",
 		"started_at":"1991-05-21T00:00:00Z",
 		"stopped_at":"2019-05-21T00:00:00Z",
@@ -295,6 +303,7 @@ func TestIfGetShowsStatusWithoutAFileWhenBundleIsDeleted(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(bundleWorkDir, stateFileName),
 		[]byte(`{
 		"id": "bundle",
+		"type": "Local",
 		"status": "Deleted",
 		"started_at":"1991-05-21T00:00:00Z",
 		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
@@ -314,6 +323,7 @@ func TestIfGetShowsStatusWithoutAFileWhenBundleIsDeleted(t *testing.T) {
 
 	assert.JSONEq(t, `{
 		"id": "bundle",
+		"type": "Local",
 		"status": "Deleted",
 		"started_at":"1991-05-21T00:00:00Z",
 		"stopped_at":"2019-05-21T00:00:00Z"
@@ -332,6 +342,7 @@ func TestIfGetShowsStatusWithoutAFileWhenBundleIsDone(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(bundleWorkDir, stateFileName),
 		[]byte(`{
 		"id": "bundle",
+		"type": "Local",
 		"status": "Done",
 		"started_at":"1991-05-21T00:00:00Z",
 		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
@@ -351,7 +362,7 @@ func TestIfGetShowsStatusWithoutAFileWhenBundleIsDone(t *testing.T) {
 
 	assert.Contains(t,
 		rr.Body.String(),
-		`{"id":"bundle","status":"Unknown","started_at":"1991-05-21T00:00:00Z","stopped_at":"2019-05-21T00:00:00Z","errors":["could not stat data file bundle: `,
+		`{"id":"bundle","type":"Local","status":"Unknown","started_at":"1991-05-21T00:00:00Z","stopped_at":"2019-05-21T00:00:00Z","errors":["could not stat data file bundle: `,
 	)
 }
 
@@ -380,6 +391,7 @@ func TestIfGetReturns500WhenBundleStateIsNotJson(t *testing.T) {
 	assert.JSONEq(t,
 		`{
    			"id":"bundle-state-not-json",
+			"type": "Local",
 			"status":"Unknown",
    			"started_at":"0001-01-01T00:00:00Z",
    			"stopped_at":"0001-01-01T00:00:00Z",
@@ -433,7 +445,7 @@ func TestIfDeleteReturns500WhenNoBundleStateFound(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Contains(t,
 		rr.Body.String(),
-		`{"id":"not-existing-bundle-state","status":"Unknown","started_at":"0001-01-01T00:00:00Z","stopped_at":"0001-01-01T00:00:00Z","errors":["could not read state file for bundle not-existing-bundle-state:`,
+		`{"id":"not-existing-bundle-state","type":"Local","status":"Unknown","started_at":"0001-01-01T00:00:00Z","stopped_at":"0001-01-01T00:00:00Z","errors":["could not read state file for bundle not-existing-bundle-state:`,
 	)
 }
 
@@ -465,6 +477,7 @@ func TestIfDeleteReturns500WhenBundleStateIsNotJson(t *testing.T) {
 	assert.JSONEq(t,
 		`{
    			"id":"bundle-state-not-json",
+			"type": "Local",
    			"status":"Unknown",
    			"started_at":"0001-01-01T00:00:00Z",
    			"stopped_at":"0001-01-01T00:00:00Z",
@@ -487,6 +500,7 @@ func TestIfDeleteReturns304WhenBundleWasDeletedBefore(t *testing.T) {
 	stateFilePath := filepath.Join(bundleWorkDir, stateFileName)
 	bundleState := `{
 		"id": "bundle",
+		"type": "Local",
 		"status": "Deleted",
 		"started_at":"1991-05-21T00:00:00Z",
 		"stopped_at":"2019-05-21T00:00:00Z" }`
@@ -538,7 +552,7 @@ func TestIfDeleteReturns500WhenBundleFileIsMissing(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Contains(t,
 		rr.Body.String(),
-		`{"id":"bundle","status":"Unknown","started_at":"1991-05-21T00:00:00Z","stopped_at":"2019-05-21T00:00:00Z","errors":["could not stat data file missing-data-file: `,
+		`{"id":"bundle","type":"Local","status":"Unknown","started_at":"1991-05-21T00:00:00Z","stopped_at":"2019-05-21T00:00:00Z","errors":["could not stat data file missing-data-file: `,
 		rr.Body.String(),
 	)
 }
@@ -554,6 +568,7 @@ func TestIfDeleteReturns200WhenBundleWasDeleted(t *testing.T) {
 	stateFilePath := filepath.Join(bundleWorkDir, stateFileName)
 	err = ioutil.WriteFile(stateFilePath, []byte((`{
 		"id": "bundle-0",
+		"type": "Local",
 		"status": "Done",
 		"size": 2,
 		"started_at":"1991-05-21T00:00:00Z",
@@ -576,6 +591,7 @@ func TestIfDeleteReturns200WhenBundleWasDeleted(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.JSONEq(t, `{
 		"id": "bundle-0",
+		"type": "Local",
 		"status": "Deleted",
 		"size": 2,
 		"started_at":"1991-05-21T00:00:00Z",
@@ -734,6 +750,7 @@ func TestIfE2E_(t *testing.T) {
 
 		assert.Equal(t, &Bundle{
 			ID:      "bundle-0",
+			Type:    Local,
 			Status:  Started,
 			Started: now.Add(time.Hour),
 		}, bundle)
@@ -753,6 +770,7 @@ func TestIfE2E_(t *testing.T) {
 
 		assert.Equal(t, &Bundle{
 			ID:      "bundle-0",
+			Type:    Local,
 			Status:  Done,
 			Started: now.Add(time.Hour),
 			Stopped: now.Add(2 * time.Hour),
@@ -827,6 +845,7 @@ func TestIfE2E_(t *testing.T) {
 
 		assert.JSONEq(t, string(jsonMarshal(Bundle{
 			ID:      "bundle-0",
+			Type:    Local,
 			Status:  Deleted,
 			Started: now.Add(time.Hour),
 			Stopped: now.Add(2 * time.Hour),
@@ -846,6 +865,7 @@ func TestIfE2E_(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.JSONEq(t, string(jsonMarshal([]Bundle{{
 			ID:      "bundle-0",
+			Type:    Local,
 			Status:  Deleted,
 			Started: now.Add(time.Hour),
 			Stopped: now.Add(2 * time.Hour),

--- a/api/rest/cluster_bundle_handler.go
+++ b/api/rest/cluster_bundle_handler.go
@@ -66,6 +66,7 @@ func (c *ClusterBundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	bundle := Bundle{
 		ID:      id,
+		Type:    Cluster,
 		Started: c.clock.Now(),
 		Status:  Started,
 	}

--- a/api/rest/cluster_bundle_handler_test.go
+++ b/api/rest/cluster_bundle_handler_test.go
@@ -321,6 +321,7 @@ func TestStatusForBundle(t *testing.T) {
 	client.On("Status", ctx, "http://192.0.2.2", "bundle-0").Return(nil, fmt.Errorf("asdf"))
 	client.On("Status", ctx, "http://192.0.2.4", "bundle-0").Return(&Bundle{
 		ID:      "bundle-0",
+		Type:    Cluster,
 		Status:  Done,
 		Started: now,
 		Stopped: now.Add(1 * time.Hour),
@@ -350,6 +351,7 @@ func TestStatusForBundle(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.JSONEq(t, string(jsonMarshal(Bundle{
 		ID:      "bundle-0",
+		Type:    Cluster,
 		Status:  Done,
 		Started: now,
 		Stopped: now.Add(time.Hour),
@@ -496,7 +498,8 @@ func TestDownloadBundle(t *testing.T) {
 	client.On("Status", ctx, "http://192.0.2.2", id).Return(nil, &DiagnosticsBundleNotFoundError{id: id})
 	client.On("Status", ctx, "http://192.0.2.4", id).Return(nil, &DiagnosticsBundleNotFoundError{id: id})
 	client.On("Status", ctx, "http://192.0.2.5", id).Return(&Bundle{
-		ID: "bundle-0",
+		ID:   "bundle-0",
+		Type: Cluster,
 	}, nil)
 	client.On("GetFile", ctx, "http://192.0.2.5", id, mock.AnythingOfType("string")).Return(func(ctx context.Context, url string, id string, tempZipFile string) error {
 		// copy the testdata zip to the location Client is expected to put the downloaded zip
@@ -672,13 +675,16 @@ func TestListWithBundlesOnMultipleMasters(t *testing.T) {
 
 	expectedBundles := []*Bundle{
 		{
-			ID: "bundle-0",
+			ID:   "bundle-0",
+			Type: Cluster,
 		},
 		{
-			ID: "bundle-1",
+			ID:   "bundle-1",
+			Type: Cluster,
 		},
 		{
-			ID: "bundle-2",
+			ID:   "bundle-2",
+			Type: Cluster,
 		},
 	}
 
@@ -750,6 +756,7 @@ func TestRemoteBundleCreation(t *testing.T) {
 	client := new(TestifyMockClient)
 	client.On("Status", ctx, "http://192.0.2.2", "bundle-0").Return(&Bundle{
 		ID:      "bundle-0",
+		Type:    Cluster,
 		Started: now.Add(time.Hour),
 		Stopped: now.Add(2 * time.Hour),
 		Status:  Done,
@@ -790,6 +797,7 @@ func TestRemoteBundleCreation(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.JSONEq(t, string(jsonMarshal(Bundle{
 			ID:      "bundle-0",
+			Type:    Cluster,
 			Status:  Started,
 			Started: now.Add(time.Hour),
 		})), rr.Body.String())
@@ -826,6 +834,7 @@ func TestRemoteBundleCreation(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.JSONEq(t, string(jsonMarshal(Bundle{
 			ID:      "bundle-0",
+			Type:    Cluster,
 			Status:  Done,
 			Started: now.Add(time.Hour),
 			Stopped: now.Add(2 * time.Hour),

--- a/api/rest/type.go
+++ b/api/rest/type.go
@@ -11,7 +11,7 @@ type Type int
 
 const (
 	Local Type = iota
-	Remote
+	Cluster
 )
 
 func (s Type) String() string {
@@ -19,13 +19,13 @@ func (s Type) String() string {
 }
 
 var typeToString = map[Type]string{
-	Local:  "Local",
-	Remote: "Remote",
+	Local:   "Local",
+	Cluster: "Cluster",
 }
 
 var stringToType = map[string]Type{
-	"Local":  Local,
-	"Remote": Remote,
+	"Local":   Local,
+	"Cluster": Cluster,
 }
 
 // MarshalJSON marshals the enum as a quoted json string

--- a/api/rest/type_test.go
+++ b/api/rest/type_test.go
@@ -12,7 +12,7 @@ func TestType_MarshalUnmarshalJSON(t *testing.T) {
 		s      string
 		j      string
 		actual Type
-	}{{"Local", `"Local"`, Local}, {"Remote", `"Remote"`, Remote}} {
+	}{{"Local", `"Local"`, Local}, {"Cluster", `"Cluster"`, Cluster}} {
 
 		t.Run(tt.s, func(t *testing.T) {
 			var actual Type


### PR DESCRIPTION
We stopped using Type after switching away from the old approach of using one API where the request specified what type of bundle to make so I repurposed it so that we can know if a bundle is a cluster bundle or a local bundle.

Addresses: https://jira.mesosphere.com/browse/DCOS_OSS-5456