### PR TITLE
Use Buffered channels

### DIFF
--- a/api/rest/coordinator.go
+++ b/api/rest/coordinator.go
@@ -109,8 +109,6 @@ func (c ParallelCoordinator) CreateBundle(ctx context.Context, id string, nodes 
 	}
 
 	for _, n := range nodes {
-		logrus.WithField("IP", n.IP).Info("Sending creation request to node.")
-
 		// necessary to prevent the closure from giving the same node to all the calls
 		tmpNode := n
 		jobs <- func(ctx context.Context) BundleStatus {

--- a/api/rest/coordinator.go
+++ b/api/rest/coordinator.go
@@ -101,8 +101,8 @@ func worker(ctx context.Context, jobs <-chan job, statuses chan<- BundleStatus) 
 // on the returned channel.
 func (c ParallelCoordinator) CreateBundle(ctx context.Context, id string, nodes []node) <-chan BundleStatus {
 
-	jobs := make(chan job)
-	statuses := make(chan BundleStatus)
+	jobs := make(chan job, len(nodes))
+	statuses := make(chan BundleStatus, len(nodes))
 
 	for i := 0; i < numberOfWorkers; i++ {
 		go worker(ctx, jobs, statuses)


### PR DESCRIPTION
When number of nodes is greater than number of workers application hangs. We have a deadlock because workers try to push result of their job to unbuffered channel that no gorutine is reading from.
To simulate this behavior change `numberOfWorkers` to 1 and see hanging tests.

https://github.com/dcos/dcos-diagnostics/blob/d9d8809a82ebb28755c0f5d7e1aa632f6c05ca6c/api/rest/coordinator.go#L19

Deleted comment duplicates:
https://github.com/dcos/dcos-diagnostics/blob/e92ee3ba8ace8e8cc4532bb4875736f0a19f2c11/api/rest/client.go#L47