### PR TITLE
Use go 1.12 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 dist: xenial
 
 go:
-- 1.x
+- 1.12
 - tip
 
 env:


### PR DESCRIPTION
Go 1.13 leads to failing CI we need to investigate and fix it.

Sww: https://travis-ci.org/dcos/dcos-diagnostics/jobs/580355340