### PR TITLE
Limit how long single collector can work

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -710,7 +710,7 @@ func (j *DiagnosticsJob) cancel() (response diagnosticsReportResponse, err error
 		status := "Attempting to cancel a job on a remote host. POST " + url
 		logrus.Debug(status)
 		j.setStatus(status)
-		response, _, err := j.DCOSTools.Post(url, j.Cfg.GetHTTPTimeout())
+		response, _, err := j.DCOSTools.Post(url, j.Cfg.GetSingleEntryTimeout())
 		if err != nil {
 			return prepareResponseWithErr(http.StatusServiceUnavailable, err)
 		}
@@ -950,7 +950,7 @@ func (j *DiagnosticsJob) Init() error {
 		}
 	}
 
-	j.client = util.NewHTTPClient(j.Cfg.GetHTTPTimeout(), j.Transport)
+	j.client = util.NewHTTPClient(j.Cfg.GetSingleEntryTimeout(), j.Transport)
 
 	return nil
 }

--- a/api/rest/bundle_handler.go
+++ b/api/rest/bundle_handler.go
@@ -67,7 +67,7 @@ type realClock struct{}
 
 func (realClock) Now() time.Time { return time.Now() }
 
-func NewBundleHandler(workDir string, collectors []collector.Collector, timeout time.Duration) (*BundleHandler, error) {
+func NewBundleHandler(workDir string, collectors []collector.Collector, timeout, collectorTimeout time.Duration) (*BundleHandler, error) {
 	err := initializeWorkDir(workDir)
 	if err != nil {
 		return nil, err
@@ -79,6 +79,7 @@ func NewBundleHandler(workDir string, collectors []collector.Collector, timeout 
 		workDir:               workDir,
 		collectors:            collectors,
 		bundleCreationTimeout: timeout,
+		collectorTimeout:      collectorTimeout,
 	}, nil
 }
 
@@ -90,6 +91,7 @@ type BundleHandler struct {
 	workDir               string                // location where bundles are generated and stored
 	collectors            []collector.Collector // information what should be in the bundle
 	bundleCreationTimeout time.Duration         // limits how long bundle creation could take
+	collectorTimeout      time.Duration         // limits how long single collection can take
 }
 
 type node struct {
@@ -144,7 +146,7 @@ func (h BundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 	ctx, _ := context.WithTimeout(context.Background(), h.bundleCreationTimeout) //nolint:govet
 	done := make(chan []string)
 
-	go collectAll(ctx, done, dataFile, h.collectors)
+	go collectAll(ctx, done, dataFile, h.collectors, h.collectorTimeout)
 
 	go func() {
 		select {
@@ -162,7 +164,8 @@ func (h BundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 	write(w, bundleStatus)
 }
 
-func collectAll(ctx context.Context, done chan<- []string, dataFile io.WriteCloser, collectors []collector.Collector) {
+func collectAll(ctx context.Context, done chan<- []string, dataFile io.WriteCloser,
+	collectors []collector.Collector, collectorTimeout time.Duration) {
 	zipWriter := zip.NewWriter(dataFile)
 	var errors []string
 	// summaryReport is a log of a diagnostics job
@@ -174,7 +177,7 @@ func collectAll(ctx context.Context, done chan<- []string, dataFile io.WriteClos
 			break
 		}
 		summaryReport.WriteString(fmt.Sprintf("[START GET %s]\n", c.Name()))
-		err := collect(ctx, c, zipWriter)
+		err := collect(ctx, c, zipWriter, collectorTimeout)
 		summaryReport.WriteString(fmt.Sprintf("[STOP GET %s]\n", c.Name()))
 		if err != nil && !c.Optional() {
 			errors = append(errors, err.Error())
@@ -211,7 +214,8 @@ func collectAll(ctx context.Context, done chan<- []string, dataFile io.WriteClos
 	done <- errors
 }
 
-func collect(ctx context.Context, c collector.Collector, zipWriter *zip.Writer) error {
+func collect(ctx context.Context, c collector.Collector, zipWriter *zip.Writer, timeout time.Duration) error {
+	ctx, _ = context.WithTimeout(ctx, timeout) //nolint: govet
 	rc, err := c.Collect(ctx)
 	if err != nil {
 		if !c.Optional() {

--- a/api/rest/bundle_handler.go
+++ b/api/rest/bundle_handler.go
@@ -177,7 +177,8 @@ func collectAll(ctx context.Context, done chan<- []string, dataFile io.WriteClos
 			break
 		}
 		summaryReport.WriteString(fmt.Sprintf("[START GET %s]\n", c.Name()))
-		collectorCtx, _ := context.WithTimeout(ctx, collectorTimeout) //nolint: govet
+		collectorCtx, cancel := context.WithTimeout(ctx, collectorTimeout) //nolint: govet
+		defer cancel()
 		err := collect(collectorCtx, c, zipWriter)
 		summaryReport.WriteString(fmt.Sprintf("[STOP GET %s]\n", c.Name()))
 		if err != nil && !c.Optional() {

--- a/api/rest/bundle_handler.go
+++ b/api/rest/bundle_handler.go
@@ -178,8 +178,8 @@ func collectAll(ctx context.Context, done chan<- []string, dataFile io.WriteClos
 		}
 		summaryReport.WriteString(fmt.Sprintf("[START GET %s]\n", c.Name()))
 		collectorCtx, cancel := context.WithTimeout(ctx, collectorTimeout) //nolint: govet
-		defer cancel()
 		err := collect(collectorCtx, c, zipWriter)
+		cancel()
 		summaryReport.WriteString(fmt.Sprintf("[STOP GET %s]\n", c.Name()))
 		if err != nil && !c.Optional() {
 			errors = append(errors, err.Error())

--- a/api/rest/bundle_handler.go
+++ b/api/rest/bundle_handler.go
@@ -177,7 +177,8 @@ func collectAll(ctx context.Context, done chan<- []string, dataFile io.WriteClos
 			break
 		}
 		summaryReport.WriteString(fmt.Sprintf("[START GET %s]\n", c.Name()))
-		err := collect(ctx, c, zipWriter, collectorTimeout)
+		collectorCtx, _ := context.WithTimeout(ctx, collectorTimeout) //nolint: govet
+		err := collect(collectorCtx, c, zipWriter)
 		summaryReport.WriteString(fmt.Sprintf("[STOP GET %s]\n", c.Name()))
 		if err != nil && !c.Optional() {
 			errors = append(errors, err.Error())
@@ -214,8 +215,7 @@ func collectAll(ctx context.Context, done chan<- []string, dataFile io.WriteClos
 	done <- errors
 }
 
-func collect(ctx context.Context, c collector.Collector, zipWriter *zip.Writer, timeout time.Duration) error {
-	ctx, _ = context.WithTimeout(ctx, timeout) //nolint: govet
+func collect(ctx context.Context, c collector.Collector, zipWriter *zip.Writer) error {
 	rc, err := c.Collect(ctx)
 	if err != nil {
 		if !c.Optional() {

--- a/api/rest/bundle_handler.go
+++ b/api/rest/bundle_handler.go
@@ -231,7 +231,7 @@ func collect(ctx context.Context, c collector.Collector, zipWriter *zip.Writer) 
 		return fmt.Errorf("could not create a %s in the zip: %s", c.Name(), err)
 	}
 	if _, err := io.Copy(zipFile, rc); err != nil {
-		return fmt.Errorf("could not copy data to zip: %s", err)
+		return fmt.Errorf("could not copy %s data to zip: %s", c.Name(), err)
 	}
 
 	return nil

--- a/api/rest/bundle_handler_test.go
+++ b/api/rest/bundle_handler_test.go
@@ -25,6 +25,8 @@ import (
 const (
 	bundleEndpoint     = bundlesEndpoint + "/{id}"
 	bundleFileEndpoint = bundleEndpoint + "/file"
+
+	collectorTimeout = time.Millisecond
 )
 
 func TestIfReturnsEmptyListWhenDirIsEmpty(t *testing.T) {
@@ -34,7 +36,7 @@ func TestIfReturnsEmptyListWhenDirIsEmpty(t *testing.T) {
 	defer os.RemoveAll(workdir)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
@@ -59,7 +61,7 @@ func TestIfReturnsEmptyListWhenDirIsEmptyContainsNoDirs(t *testing.T) {
 	_, err = ioutil.TempFile(workdir, "")
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
@@ -86,7 +88,7 @@ func TestIfDirsAsBundlesIdsWithStatusUnknown(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
@@ -141,7 +143,7 @@ func TestIfListShowsStatusWithoutAFile(t *testing.T) {
 		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
@@ -171,7 +173,7 @@ func TestIfListWorksWithoutBundleDir(t *testing.T) {
 	err = os.RemoveAll(workdir)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
@@ -203,7 +205,7 @@ func TestIfShowsStatusWithoutAFileButStatusDoneShouldChangeStatusToUnknown(t *te
 		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
@@ -246,7 +248,7 @@ func TestIfShowsStatusWithFileAndDontUpdatesFileSize(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(bundleWorkDir, dataFileName), []byte(`OK`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint, nil)
@@ -292,7 +294,7 @@ func TestIfGetShowsStatusWithoutAFileWhenBundleIsDeleted(t *testing.T) {
 		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle", nil)
@@ -332,7 +334,7 @@ func TestIfGetShowsStatusWithoutAFileWhenBundleIsDone(t *testing.T) {
 		"stopped_at":"2019-05-21T00:00:00Z" }`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle", nil)
@@ -364,7 +366,7 @@ func TestIfGetReturns500WhenBundleStateIsNotJson(t *testing.T) {
 		[]byte(`invalid JSON`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle-state-not-json", nil)
@@ -396,7 +398,7 @@ func TestIfDeleteReturns404WhenNoBundleFound(t *testing.T) {
 	defer os.RemoveAll(workdir)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Nanosecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Nanosecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/not-existing-bundle", nil)
@@ -422,7 +424,7 @@ func TestIfDeleteReturns500WhenNoBundleStateFound(t *testing.T) {
 	err = os.Mkdir(bundleWorkDir, dirPerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/not-existing-bundle-state", nil)
@@ -454,7 +456,7 @@ func TestIfDeleteReturns500WhenBundleStateIsNotJson(t *testing.T) {
 		[]byte(`invalid JSON`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/bundle-state-not-json", nil)
@@ -500,7 +502,7 @@ func TestIfDeleteReturns200WhenBundleWasDeletedBefore(t *testing.T) {
 	err = ioutil.WriteFile(stateFilePath, []byte(bundleState), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/deleted-bundle", nil)
@@ -532,7 +534,7 @@ func TestIfDeleteReturns500WhenBundleFileIsMissing(t *testing.T) {
 		"stopped_at":"2019-05-21T00:00:00Z" }`)), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/missing-data-file", nil)
@@ -572,7 +574,7 @@ func TestIfDeleteReturns200WhenBundleWasDeleted(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(bundleWorkDir, dataFileName), []byte(`OK`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodDelete, bundlesEndpoint+"/bundle-0", nil)
@@ -618,7 +620,7 @@ func TestIfGetFileReturnsBundle(t *testing.T) {
 		[]byte(`OK`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle", nil)
@@ -661,7 +663,7 @@ func TestIfGetFileReturns404WhenBundleIsStarted(t *testing.T) {
 		[]byte(`OK`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle", nil)
@@ -706,7 +708,7 @@ func TestIfGetFileReturns410WhenBundleIsNotDone(t *testing.T) {
 		[]byte(`OK`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle", nil)
@@ -731,7 +733,7 @@ func TestIfGetFileReturnsErrorWhenBundleDoesNotExists(t *testing.T) {
 	defer os.RemoveAll(workdir)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, bundlesEndpoint+"/bundle", nil)
@@ -766,7 +768,7 @@ func TestIfCreateReturns409WhenBundleWithGivenIdAlreadyExists(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(bundleWorkDir, dataFileName), []byte(`OK`), filePerm)
 	require.NoError(t, err)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, bundlesEndpoint+"/bundle-0", nil)
@@ -791,7 +793,7 @@ func TestIfCreateReturns507WhenCouldNotCreateWorkDir(t *testing.T) {
 	bundleWorkDir := filepath.Join(workdir, "bundle-0")
 	err = ioutil.WriteFile(bundleWorkDir, []byte{}, 0000)
 
-	bh, err := NewBundleHandler(workdir, nil, time.Millisecond)
+	bh, err := NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, bundlesEndpoint+"/bundle-0", nil)
@@ -824,6 +826,7 @@ func TestIfE2E_(t *testing.T) {
 			MockCollector{name: "collector-3", err: fmt.Errorf("some other error"), optional: true},
 		},
 		time.Second,
+		collectorTimeout,
 	)
 	require.NoError(t, err)
 	bh.clock = &MockClock{now: now}
@@ -985,7 +988,7 @@ func TestBundleHandlerWorkDirIsCreatedIfNotExists(t *testing.T) {
 	err = os.RemoveAll(workdir)
 	require.NoError(t, err)
 
-	_, err = NewBundleHandler(workdir, nil, time.Millisecond)
+	_, err = NewBundleHandler(workdir, nil, time.Millisecond, collectorTimeout)
 	require.NoError(t, err)
 
 	assert.DirExists(t, workdir)
@@ -998,7 +1001,7 @@ func TestBundleHandlerWorkDirInitFailsWhenFileExists(t *testing.T) {
 	workdir, err := ioutil.TempFile("", "work-dir")
 	require.NoError(t, err)
 
-	_, err = NewBundleHandler(workdir.Name(), nil, time.Millisecond)
+	_, err = NewBundleHandler(workdir.Name(), nil, time.Millisecond, collectorTimeout)
 	assert.Error(t, err)
 }
 

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -91,7 +91,7 @@ func startDiagnosticsDaemon() {
 		logrus.Fatalf("Could not init diagnostics job properly: %s", err)
 	}
 
-	client := util.NewHTTPClient(defaultConfig.GetHTTPTimeout(), tr)
+	client := util.NewHTTPClient(defaultConfig.GetSingleEntryTimeout(), tr)
 
 	collectors, err := api.LoadCollectors(defaultConfig, DCOSTools, client)
 	if err != nil {
@@ -99,7 +99,12 @@ func startDiagnosticsDaemon() {
 	}
 
 	bundleTimeout := time.Minute * time.Duration(defaultConfig.FlagDiagnosticsJobTimeoutMinutes)
-	bundleHandler, err := rest.NewBundleHandler(defaultConfig.FlagDiagnosticsBundleDir, collectors, bundleTimeout)
+	bundleHandler, err := rest.NewBundleHandler(
+		defaultConfig.FlagDiagnosticsBundleDir,
+		collectors,
+		bundleTimeout,
+		defaultConfig.GetSingleEntryTimeout(),
+	)
 	if err != nil {
 		logrus.WithError(err).Fatal("BundleHandler could not be created")
 	}
@@ -167,7 +172,7 @@ func getNodeInfo(tr http.RoundTripper) (nodeutil.NodeInfo, error) {
 	if defaultConfig.FlagIPDiscoveryCommandLocation != "" {
 		options = append(options, nodeutil.OptionDetectIP(defaultConfig.FlagIPDiscoveryCommandLocation))
 	}
-	return nodeutil.NewNodeInfo(util.NewHTTPClient(defaultConfig.GetHTTPTimeout(), tr), defaultConfig.FlagRole, options...)
+	return nodeutil.NewNodeInfo(util.NewHTTPClient(defaultConfig.GetSingleEntryTimeout(), tr), defaultConfig.FlagRole, options...)
 }
 
 func initTransport() (http.RoundTripper, error) {

--- a/cmd/mesos_state.go
+++ b/cmd/mesos_state.go
@@ -40,7 +40,7 @@ func getMesosState(tr http.RoundTripper, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	client := util.NewHTTPClient(defaultConfig.GetHTTPTimeout(), tr)
+	client := util.NewHTTPClient(defaultConfig.GetSingleEntryTimeout(), tr)
 
 	resp, err := client.Get(stateURL)
 	if err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -66,7 +66,7 @@ func Test_initConfig(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, defaultConfig)
-	assert.Equal(t, time.Minute, defaultConfig.GetHTTPTimeout())
+	assert.Equal(t, time.Minute, defaultConfig.GetSingleEntryTimeout())
 
 }
 
@@ -106,7 +106,7 @@ func Test_initConfig_multiple_endpints_configs(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, defaultConfig)
-	assert.Equal(t, time.Minute, defaultConfig.GetHTTPTimeout())
+	assert.Equal(t, time.Minute, defaultConfig.GetSingleEntryTimeout())
 
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,6 @@ type Config struct {
 	FlagDiagnosticsBundleFetchersCount           int      `mapstructure:"fetchers-count"`
 }
 
-func (c Config) GetHTTPTimeout() time.Duration {
+func (c Config) GetSingleEntryTimeout() time.Duration {
 	return time.Duration(c.FlagDiagnosticsJobGetSingleURLTimeoutMinutes) * time.Minute
 }


### PR DESCRIPTION
This PR creates dedicated context for each `Collect()` to limit time we spent on collection. 
Not all collectors supports context by default some of them use this wrapper https://github.com/dcos/dcos-diagnostics/blob/2457ed661d38f65fedede99ab0ec8e5b372cdc4f/io/readcloser.go#L9-L26
Context cancelation will result in error not on collector level but on data copy step https://github.com/dcos/dcos-diagnostics/blob/6048a18251e34b30ba61aef7edf2480b9f59e7f9/api/rest/bundle_handler.go#L232-L234
Fixes: https://jira.mesosphere.com/browse/DCOS_OSS-5516