### PR TITLE
Do not use pointers in options.

### DIFF
--- a/api/rest/cluster_bundle_handler.go
+++ b/api/rest/cluster_bundle_handler.go
@@ -97,7 +97,7 @@ func (c *ClusterBundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	var masters, agents []dcos.Node
 
-	if options.Masters == nil || *options.Masters == true {
+	if options.Masters == true {
 		masters, err = c.tools.GetMasterNodes()
 		if err != nil {
 			if e := c.failed(bundle, err); e != nil {
@@ -108,7 +108,7 @@ func (c *ClusterBundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if options.Agents == nil || *options.Agents == true {
+	if options.Agents == true {
 		agents, err = c.tools.GetAgentNodes()
 		if err != nil {
 			if e := c.failed(bundle, err); e != nil {
@@ -157,15 +157,21 @@ func (c *ClusterBundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 type options struct {
-	Masters *bool `json:"masters"`
-	Agents  *bool `json:"agents"`
+	Masters bool `json:"masters"`
+	Agents  bool `json:"agents"`
 }
 
-func getOptionsFromRequest(r *http.Request) (o options, err error) {
+var defaultOptions = options{
+	Masters: true,
+	Agents:  true,
+}
+
+func getOptionsFromRequest(r *http.Request) (options, error) {
+	o := defaultOptions
 	if r.Body != nil {
-		if err = json.NewDecoder(r.Body).Decode(&o); err != nil {
+		if err := json.NewDecoder(r.Body).Decode(&o); err != nil {
 			if err != io.EOF { // Accept empty body
-				return options{}, err
+				return o, err
 			}
 		}
 	}

--- a/api/rest/cluster_bundle_handler.go
+++ b/api/rest/cluster_bundle_handler.go
@@ -108,7 +108,7 @@ func (c *ClusterBundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if options.Agents == true {
+	if options.Agents {
 		agents, err = c.tools.GetAgentNodes()
 		if err != nil {
 			if e := c.failed(bundle, err); e != nil {

--- a/api/rest/cluster_bundle_handler.go
+++ b/api/rest/cluster_bundle_handler.go
@@ -97,7 +97,7 @@ func (c *ClusterBundleHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	var masters, agents []dcos.Node
 
-	if options.Masters == true {
+	if options.Masters {
 		masters, err = c.tools.GetMasterNodes()
 		if err != nil {
 			if e := c.failed(bundle, err); e != nil {


### PR DESCRIPTION
Instead of pointers use `defaulOptions` to fill default values for
options.

See:
* https://stackoverflow.com/a/39161308/1387612
* https://github.com/dcos/dcos-diagnostics/pull/159#discussion_r331935835

Fixes: https://jira.mesosphere.com/browse/DCOS_OSS-5472