### PR TITLE
Small improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 dist: xenial
 
 go:
-- 1.12
+- 1.13
 - tip
 
 env:
@@ -15,7 +15,7 @@ matrix:
 
 before_install:
 - sudo apt-get install -y libsystemd-dev
-- curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
+- curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
 
 script:
   - golangci-lint run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.5
+FROM golang:1.13
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
@@ -6,4 +6,4 @@ ENV GOPATH /go
 RUN apt-get update && apt-get install -y \
     libsystemd-dev
 
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0

--- a/api/rest/bundle_handler_test.go
+++ b/api/rest/bundle_handler_test.go
@@ -878,7 +878,7 @@ func TestIfE2E_(t *testing.T) {
 			Status:  Done,
 			Started: now.Add(time.Hour),
 			Stopped: now.Add(2 * time.Hour),
-			Size:    803,
+			Size:    618,
 			Errors: []string{
 				"could not collect collector-1: some error",
 				"could not copy collector-4 data to zip: context deadline exceeded",
@@ -899,12 +899,11 @@ func TestIfE2E_(t *testing.T) {
 		reader, err := zip.OpenReader(f.Name())
 		require.NoError(t, err)
 
-		require.Len(t, reader.File, 5)
+		require.Len(t, reader.File, 4)
 		assert.Equal(t, "collector-2", reader.File[0].Name)
 		assert.Equal(t, "collector-3", reader.File[1].Name)
 		assert.Equal(t, "collector-4", reader.File[2].Name)
-		assert.Equal(t, "summaryReport.txt", reader.File[3].Name)
-		assert.Equal(t, "summaryErrorsReport.txt", reader.File[4].Name)
+		assert.Equal(t, "summaryErrorsReport.txt", reader.File[3].Name)
 
 		rc, err := reader.File[0].Open()
 		require.NoError(t, err)
@@ -925,21 +924,6 @@ func TestIfE2E_(t *testing.T) {
 		assert.Empty(t, content)
 
 		rc, err = reader.File[3].Open()
-		require.NoError(t, err)
-		content, err = ioutil.ReadAll(rc)
-		require.NoError(t, err)
-		assert.Equal(t,
-			`[START GET collector-1]
-[STOP GET collector-1]
-[START GET collector-2]
-[STOP GET collector-2]
-[START GET collector-3]
-[STOP GET collector-3]
-[START GET collector-4]
-[STOP GET collector-4]
-`, string(content))
-
-		rc, err = reader.File[4].Open()
 		require.NoError(t, err)
 		content, err = ioutil.ReadAll(rc)
 		require.NoError(t, err)
@@ -967,7 +951,7 @@ could not copy collector-4 data to zip: context deadline exceeded`, string(conte
 			Status:  Deleted,
 			Started: now.Add(time.Hour),
 			Stopped: now.Add(2 * time.Hour),
-			Size:    803,
+			Size:    618,
 			Errors:  []string{
 				"could not collect collector-1: some error",
 				"could not copy collector-4 data to zip: context deadline exceeded",
@@ -990,7 +974,7 @@ could not copy collector-4 data to zip: context deadline exceeded`, string(conte
 			Status:  Deleted,
 			Started: now.Add(time.Hour),
 			Stopped: now.Add(2 * time.Hour),
-			Size:    803,
+			Size:    618,
 			Errors:  []string{
 				"could not collect collector-1: some error",
 				"could not copy collector-4 data to zip: context deadline exceeded",

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -44,7 +44,7 @@ func NewDiagnosticsClient(client *http.Client) DiagnosticsClient {
 func (d DiagnosticsClient) CreateBundle(ctx context.Context, node string, ID string) (*Bundle, error) {
 	url := remoteURL(node, ID)
 
-	logrus.WithField("ID", ID).WithField("url", url).Info("sending bundle creation request")
+	logrus.WithField("ID", ID).WithField("url", url).Debug("sending bundle creation request")
 
 	type payload struct {
 		Type Type `json:"type"`
@@ -84,7 +84,7 @@ func (d DiagnosticsClient) CreateBundle(ctx context.Context, node string, ID str
 func (d DiagnosticsClient) Status(ctx context.Context, node string, ID string) (*Bundle, error) {
 	url := remoteURL(node, ID)
 
-	logrus.WithField("ID", ID).WithField("url", url).Info("checking status of bundle")
+	logrus.WithField("ID", ID).WithField("url", url).Debug("checking status of bundle")
 
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -117,7 +117,7 @@ func (d DiagnosticsClient) Status(ctx context.Context, node string, ID string) (
 func (d DiagnosticsClient) GetFile(ctx context.Context, node string, ID string, path string) error {
 	url := fmt.Sprintf("%s/file", remoteURL(node, ID))
 
-	logrus.WithField("ID", ID).WithField("url", url).Info("downloading local bundle from node")
+	logrus.WithField("ID", ID).WithField("url", url).Debug("downloading local bundle from node")
 
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -152,7 +152,7 @@ func (d DiagnosticsClient) GetFile(ctx context.Context, node string, ID string, 
 func (d DiagnosticsClient) List(ctx context.Context, node string) ([]*Bundle, error) {
 	url := fmt.Sprintf("%s%s", node, bundlesEndpoint)
 
-	logrus.WithField("node", node).Info("getting list of bundles from node")
+	logrus.WithField("node", node).Debug("getting list of bundles from node")
 
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -185,7 +185,7 @@ func (d DiagnosticsClient) List(ctx context.Context, node string) ([]*Bundle, er
 func (d DiagnosticsClient) Delete(ctx context.Context, node string, id string) error {
 	url := remoteURL(node, id)
 
-	logrus.WithField("node", node).WithField("ID", id).Info("deleting bundle from node")
+	logrus.WithField("node", node).WithField("ID", id).Debug("deleting bundle from node")
 
 	request, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -109,7 +109,7 @@ func startDiagnosticsDaemon() {
 		logrus.WithError(err).Fatal("BundleHandler could not be created")
 	}
 	diagClient := rest.NewDiagnosticsClient(client)
-	coord := rest.NewParallelCoordinator(diagClient, 5*time.Second, defaultConfig.FlagDiagnosticsBundleDir)
+	coord := rest.NewParallelCoordinator(diagClient, time.Minute, defaultConfig.FlagDiagnosticsBundleDir)
 	urlBuilder := diagDcos.NewURLBuilder(defaultConfig.FlagAgentPort, defaultConfig.FlagMasterPort, defaultConfig.FlagForceTLS)
 	clusterBundleHandler, err := rest.NewClusterBundleHandler(coord, diagClient, DCOSTools, defaultConfig.FlagDiagnosticsBundleDir,
 		bundleTimeout, &urlBuilder)


### PR DESCRIPTION
* Reverted commit 1c0970b.
    Creating local bundle takes much more than 5s. We don't need query node every 5s about its status. This change will reduce logs noise on larger cluster.
* Changed client log level from Info to Debug
    Client should not log everything. It's logs are duplicated in coordinator. To reduce noise, let's keep only coordinator logs.
* Removed `summaryReport.txt` from bundle
    summarryReport contains no meaningful information. All errors are stored in `report.json`. It was  reated to keep compatibility with an OLD API but that make no sens when we introduced report.json where we have a structure that we can extedn to provide more information about performed
actions.
    https://github.com/dcos/dcos/pull/6032/commits/71f1ae60997731c7517532b16d7ca5b1af4c5536#diff-8fc8247f673fc5ccc152ebe2b5bb0fa0R504