### PR TITLE
Fail fast when can't get nodes

### DIFF
--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -813,7 +813,7 @@ func matchRequestedNodes(requestedNodes []string, masterNodes, agentNodes []dcos
 	var matchedNodes []dcos.Node
 	clusterNodes := append(masterNodes, agentNodes...)
 	if len(requestedNodes) == 0 {
-		return matchedNodes, errors.New("no nodes were requested")
+		return nil, errors.New("no nodes were requested")
 	}
 	if len(clusterNodes) == 0 {
 		return matchedNodes, errors.New("can't find any nodes")

--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -812,8 +812,11 @@ func (j *DiagnosticsJob) findLocalBundle() (bundles []string, err error) {
 func matchRequestedNodes(requestedNodes []string, masterNodes, agentNodes []dcos.Node) ([]dcos.Node, error) {
 	var matchedNodes []dcos.Node
 	clusterNodes := append(masterNodes, agentNodes...)
-	if len(requestedNodes) == 0 || len(clusterNodes) == 0 {
-		return matchedNodes, errors.New("Cannot match requested nodes to clusterNodes")
+	if len(requestedNodes) == 0 {
+		return matchedNodes, errors.New("no nodes were requested")
+	}
+	if len(clusterNodes) == 0 {
+		return matchedNodes, errors.New("can't find any nodes")
 	}
 
 	for _, requestedNode := range requestedNodes {
@@ -840,18 +843,18 @@ func matchRequestedNodes(requestedNodes []string, masterNodes, agentNodes []dcos
 	if len(matchedNodes) > 0 {
 		return matchedNodes, nil
 	}
-	return matchedNodes, fmt.Errorf("Requested nodes: %s not found", requestedNodes)
+	return matchedNodes, fmt.Errorf("requested nodes: %s not found", requestedNodes)
 }
 
 func findRequestedNodes(requestedNodes []string, tools dcos.Tooler) ([]dcos.Node, error) {
 	masterNodes, err := tools.GetMasterNodes()
 	if err != nil {
-		logrus.WithError(err).Errorf("Could not get master nodes")
+		return nil, fmt.Errorf("could not get master nodes: %s", err)
 	}
 
 	agentNodes, err := tools.GetAgentNodes()
 	if err != nil {
-		logrus.WithError(err).Errorf("Could not get agent nodes")
+		return nil, fmt.Errorf("could not get agent nodes: %s", err)
 	}
 	return matchRequestedNodes(requestedNodes, masterNodes, agentNodes)
 }

--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -843,7 +843,7 @@ func matchRequestedNodes(requestedNodes []string, masterNodes, agentNodes []dcos
 	if len(matchedNodes) > 0 {
 		return matchedNodes, nil
 	}
-	return matchedNodes, fmt.Errorf("requested nodes: %s not found", requestedNodes)
+	return nil, fmt.Errorf("requested nodes: %s not found", requestedNodes)
 }
 
 func findRequestedNodes(requestedNodes []string, tools dcos.Tooler) ([]dcos.Node, error) {

--- a/api/diagnostics.go
+++ b/api/diagnostics.go
@@ -816,7 +816,7 @@ func matchRequestedNodes(requestedNodes []string, masterNodes, agentNodes []dcos
 		return nil, errors.New("no nodes were requested")
 	}
 	if len(clusterNodes) == 0 {
-		return matchedNodes, errors.New("can't find any nodes")
+		return nil, errors.New("can't find any nodes")
 	}
 
 	for _, requestedNode := range requestedNodes {


### PR DESCRIPTION
When CocroachDB or Bouncer is down following response will be generated by old API
```yaml
# curl -X POST --data "{\"nodes\": [\"all\"]}" --unix-socket  /var/run/dcos/dcos-diagnostics.sock http:/system/health/v1/report/diagnostics/create
{
  "response_http_code":503,
  "version":1,
  "status":"could not get agent nodes: Get https://172.17.0.2:5050/slaves: net/http: request canceled (Client.Timeout exceeded while awaiting headers)",
}
```
The new API already returns meaningful information
```yaml
# curl -X PUT --unix-socket  /var/run/dcos/dcos-diagnostics.sock http:/system/health/v1/diagnostics/xyz
{
  "code":500,
  "error":"error getting agent nodes for bundle xyz: Get https://172.17.0.2:5050/slaves: net/http: request canceled (Client.Timeout exceeded while awaiting headers)"
}
```


Fixes: COPS-5439
Refs: https://github.com/dcos/dcos-core-cli/pull/384