### PR TITLE
Adjust diagnostic configuration files (DCOS_OSS-5662)

### DIFF
--- a/dcos/tools_windows.go
+++ b/dcos/tools_windows.go
@@ -131,7 +131,7 @@ func (st *Tools) GetUnitNames() (units []string, err error) {
 		panic(err)
 	}
 	exPath := filepath.Dir(ex)
-	servicelistpath := exPath + "\\" + WindowsServiceListFile
+	servicelistpath := exPath + "\\..\\etc\\" + WindowsServiceListFile
 
 	file, err := os.Open(servicelistpath)
 	if err != nil {

--- a/vendor/github.com/dcos/dcos-go/dcos/constants.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/constants.go
@@ -20,7 +20,8 @@ const (
 func GetFileDetectIPLocation() string {
 	switch runtime.GOOS {
 	case "windows":
-		return "/opt/mesosphere/bin/detect_ip.ps1"
+        return "c:\\dcos\\opt\\bin\\detect_ip.ps1"
+        
 	default:
 		return "/opt/mesosphere/bin/detect_ip"
 	}


### PR DESCRIPTION
Adjust the code and change the location of the configuration files of the dcos-diagnostics package in order to deploy properly together with the winpanda