### PR TITLE
Limit number of concurrent status pulls

### DIFF
--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -36,6 +36,9 @@ func testCfg() *config.Config {
 		FlagDiagnosticsJobTimeoutMinutes:   1,
 		FlagDiagnosticsBundleFetchersCount: 3,
 		FlagDiagnosticsBundleUnitsLogsSinceString: "24h",
+
+		FlagPullInterval:   60,
+		FlagPullTimeoutSec: 3,
 	}
 }
 


### PR DESCRIPTION
Currently we make as many http calls as nodes we have.
This means we may create thousands connections to remote
agents. We should limit and control this number.

This PR introduces minimal change to add rate limiting
for that process. Number of concurrent connections will
be limited just to fit in pull interval window.

See: https://jira.d2iq.com/browse/COPS-5915