### PR TITLE
Fix windows build

### DIFF
--- a/api/properties_windows.go
+++ b/api/properties_windows.go
@@ -10,7 +10,7 @@ import (
 
 // CheckUnitHealth tells if the Unit is Healthy
 func (u *UnitPropertiesResponse) CheckUnitHealth() (dcos.Health, string, error) {
-	if u.ActiveState != string(svc.Running) {
+	if u.ActiveState != fmt.Sprint(svc.Running) {
 		logrus.Infof("The ActiveState is %s, not in running state(4)", u.ActiveState)
 		return dcos.Healthy, fmt.Sprintf("The ActiveState is %s, not in running state(4)", u.ActiveState), nil
 	}

--- a/dcos/tools_windows.go
+++ b/dcos/tools_windows.go
@@ -112,11 +112,12 @@ func (st *Tools) GetUnitProperties(pname string) (map[string]interface{}, error)
 		return nil, err
 	}
 
+	s := fmt.Sprint(status.State)
 	result := make(map[string]interface{})
 	result["id"] = pname
-	result["ActiveState"] = fmt.Sprint(status.State)
-	result["LoadState"] = string(status.State)
-	result["SubState"] = string(status.State)
+	result["ActiveState"] = s
+	result["LoadState"] = s
+	result["SubState"] = s
 	result["Description"] = config.Description
 
 	logrus.WithField("Result", result).WithField("id", pname).Debug("GetUnitProperties for service")

--- a/dcos/tools_windows.go
+++ b/dcos/tools_windows.go
@@ -3,6 +3,7 @@ package dcos
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -113,7 +114,7 @@ func (st *Tools) GetUnitProperties(pname string) (map[string]interface{}, error)
 
 	result := make(map[string]interface{})
 	result["id"] = pname
-	result["ActiveState"] = string(status.State)
+	result["ActiveState"] = fmt.Sprin(status.State)
 	result["LoadState"] = string(status.State)
 	result["SubState"] = string(status.State)
 	result["Description"] = config.Description

--- a/dcos/tools_windows.go
+++ b/dcos/tools_windows.go
@@ -114,7 +114,7 @@ func (st *Tools) GetUnitProperties(pname string) (map[string]interface{}, error)
 
 	result := make(map[string]interface{})
 	result["id"] = pname
-	result["ActiveState"] = fmt.Sprin(status.State)
+	result["ActiveState"] = fmt.Sprint(status.State)
 	result["LoadState"] = string(status.State)
 	result["SubState"] = string(status.State)
 	result["Description"] = config.Description


### PR DESCRIPTION
```
# github.com/dcos/dcos-diagnostics/api
api\properties_windows.go:13: conversion from State (uint32) to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```