### PR TITLE
Fix (un)healthy mixed names

### DIFF
--- a/api/health_linux_test.go
+++ b/api/health_linux_test.go
@@ -35,9 +35,9 @@ func TestSystemdUnits_GetUnitsProperties(t *testing.T) {
 	expected := UnitsHealthResponseJSONStruct{
 		Hostname: "MyHostName", IPAddress: "127.0.0.1", DcosVersion: "", Role: "master", MesosID: "node-id-123", TdtVersion: "dev",
 		Array: []HealthResponseValues{
-			{UnitID: "unit_a", UnitHealth: dcos.Unhealthy, UnitTitle: title, PrettyName: name},
-			{UnitID: "unit_b", UnitHealth: dcos.Unhealthy, UnitTitle: title, PrettyName: name},
-			{UnitID: "unit_c", UnitHealth: dcos.Unhealthy, UnitTitle: title, PrettyName: name},
+			{UnitID: "unit_a", UnitHealth: dcos.Healthy, UnitTitle: title, PrettyName: name},
+			{UnitID: "unit_b", UnitHealth: dcos.Healthy, UnitTitle: title, PrettyName: name},
+			{UnitID: "unit_c", UnitHealth: dcos.Healthy, UnitTitle: title, PrettyName: name},
 		},
 	}
 	assert.Equal(t, expected, units)

--- a/api/health_windows.go
+++ b/api/health_windows.go
@@ -47,7 +47,7 @@ func (s *SystemdUnits) GetUnits(tools dcos.Tooler) (allUnits []HealthResponseVal
 			logrus.Errorf("Unit property error for %s", unit)
 			normalizedProperty = HealthResponseValues{
 				UnitID:     unit,
-				UnitHealth: 1,
+				UnitHealth: dcos.Unhealthy,
 				UnitOutput: "",
 				UnitTitle:  "",
 				Help:       "",

--- a/api/health_windows_test.go
+++ b/api/health_windows_test.go
@@ -24,13 +24,13 @@ func TestSystemdUnits_GetUnits(t *testing.T) {
 
 	assert.NoError(t, err)
 	expected := []HealthResponseValues{
-		{UnitID: "dcos-setup.service", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "dcos-link-env.service", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "dcos-download.service", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "unit_a", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "unit_b", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "unit_c", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "unit_to_fail", UnitHealth: dcos.Healthy},
+		{UnitID: "dcos-setup.service", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "dcos-link-env.service", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "dcos-download.service", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "unit_a", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "unit_b", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "unit_c", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "unit_to_fail", UnitHealth: dcos.Unhealthy},
 	}
 	assert.Equal(t, expected, units)
 }
@@ -44,13 +44,13 @@ func TestSystemdUnits_GetUnitsProperties(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := UnitsHealthResponseJSONStruct{Array: []HealthResponseValues{
-		{UnitID: "dcos-setup.service", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "dcos-link-env.service", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "dcos-download.service", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "unit_a", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "unit_b", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "unit_c", UnitHealth: dcos.Healthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
-		{UnitID: "unit_to_fail", UnitHealth: dcos.Healthy},
+		{UnitID: "dcos-setup.service", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "dcos-link-env.service", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "dcos-download.service", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "unit_a", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "unit_b", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "unit_c", UnitHealth: dcos.Unhealthy, UnitOutput: output, UnitTitle: title, PrettyName: name},
+		{UnitID: "unit_to_fail", UnitHealth: dcos.Unhealthy},
 	}, Hostname: "MyHostName", IPAddress: "127.0.0.1", DcosVersion: "some version", Role: "master", MesosID: "node-id-123", TdtVersion: "dev"}
 
 	assert.Equal(t, expected, units)

--- a/api/properties_linux.go
+++ b/api/properties_linux.go
@@ -11,23 +11,23 @@ import (
 // CheckUnitHealth tells if the Unit is healthy
 func (u *UnitPropertiesResponse) CheckUnitHealth() (dcos.Health, string, error) {
 	if u.LoadState == "" || u.ActiveState == "" || u.SubState == "" {
-		return dcos.Healthy, "", fmt.Errorf("LoadState: %s, ActiveState: %s and SubState: %s must be set",
+		return dcos.Unhealthy, "", fmt.Errorf("LoadState: %s, ActiveState: %s and SubState: %s must be set",
 			u.LoadState, u.ActiveState, u.SubState)
 	}
 
 	if u.LoadState != "loaded" {
-		return dcos.Healthy, fmt.Sprintf("%s is not loaded. Please check `systemctl show all` to check current Unit status.", u.ID), nil
+		return dcos.Unhealthy, fmt.Sprintf("%s is not loaded. Please check `systemctl show all` to check current Unit status.", u.ID), nil
 	}
 
 	okActiveStates := []string{"active", "inactive", "activating"}
 	if !util.IsInList(u.ActiveState, okActiveStates) {
-		return dcos.Healthy, fmt.Sprintf(
+		return dcos.Unhealthy, fmt.Sprintf(
 			"%s state is not one of the possible states %s. Current state is [ %s ]. "+
 				"Please check `systemctl show all %s` to check current Unit state. ", u.ID, okActiveStates, u.ActiveState, u.ID), nil
 	}
 	logrus.Debugf("%s| ExecMainStatus = %d", u.ID, u.ExecMainStatus)
 	if u.ExecMainStatus != 0 {
-		return dcos.Healthy, fmt.Sprintf("ExecMainStatus return failed status for %s", u.ID), nil
+		return dcos.Unhealthy, fmt.Sprintf("ExecMainStatus return failed status for %s", u.ID), nil
 	}
 
 	// https://www.freedesktop.org/wiki/Software/systemd/dbus/
@@ -36,15 +36,15 @@ func (u *UnitPropertiesResponse) CheckUnitHealth() (dcos.Health, string, error) 
 		// If ActiveEnterTimestampMonotonic is 0, it means that Unit has never been able to switch to active state.
 		// Most likely a ExecStartPre fails before the Unit can execute ExecStart.
 		if u.ActiveEnterTimestampMonotonic == 0 {
-			return dcos.Healthy, fmt.Sprintf("Unit %s has never entered `active` state", u.ID), nil
+			return dcos.Unhealthy, fmt.Sprintf("Unit %s has never entered `active` state", u.ID), nil
 		}
 
 		// If InactiveEnterTimestampMonotonic > ActiveEnterTimestampMonotonic that means that a Unit was active
 		// some time ago, but then something happened and it cannot restart.
 		if u.InactiveEnterTimestampMonotonic > u.ActiveEnterTimestampMonotonic {
-			return dcos.Healthy, fmt.Sprintf("Unit %s is flapping. Please check `systemctl status %s` to check current Unit state.", u.ID, u.ID), nil
+			return dcos.Unhealthy, fmt.Sprintf("Unit %s is flapping. Please check `systemctl status %s` to check current Unit state.", u.ID, u.ID), nil
 		}
 	}
 
-	return dcos.Unhealthy, "", nil
+	return dcos.Healthy, "", nil
 }

--- a/api/properties_windows.go
+++ b/api/properties_windows.go
@@ -12,7 +12,7 @@ import (
 func (u *UnitPropertiesResponse) CheckUnitHealth() (dcos.Health, string, error) {
 	if u.ActiveState != fmt.Sprint(svc.Running) {
 		logrus.Infof("The ActiveState is %s, not in running state(4)", u.ActiveState)
-		return dcos.Healthy, fmt.Sprintf("The ActiveState is %s, not in running state(4)", u.ActiveState), nil
+		return dcos.Unhealthy, fmt.Sprintf("The ActiveState is %s, not in running state(4)", u.ActiveState), nil
 	}
-	return dcos.Unhealthy, "", nil
+	return dcos.Healthy, "", nil
 }

--- a/dcos/interfaces.go
+++ b/dcos/interfaces.go
@@ -10,10 +10,10 @@ import (
 type Health int
 
 const (
-	// Unhealthy indicates Unit is not healthy
-	Unhealthy = 0
 	// Healthy indicates Unit is healthy
-	Healthy = 1
+	Healthy = 0
+	// Unhealthy indicates Unit is not healthy
+	Unhealthy = 1
 	// Unknown indicates Unit health could not be determined
 	Unknown = 3
 )


### PR DESCRIPTION
PR #47 introduced Healthy and Unhealthy status aliases.
Unfortunately it mismatched the constants.
This PR brings the proper names.

Refs: https://jira.d2iq.com/browse/COPS-6512