### PR TITLE
Increase collector timeout in test

### DIFF
--- a/api/rest/bundle_handler_test.go
+++ b/api/rest/bundle_handler_test.go
@@ -826,7 +826,7 @@ func TestIfE2E_(t *testing.T) {
 		MockCollector{name: "collector-4", rc: slowReader{delay: time.Millisecond}},
 	}
 
-	bh, err := NewBundleHandler(workdir, collectors, time.Second, 5 * time.Millisecond)
+	bh, err := NewBundleHandler(workdir, collectors, time.Second, 50 * time.Millisecond)
 	require.NoError(t, err)
 	bh.clock = &MockClock{now: now}
 


### PR DESCRIPTION
We have a flaky test due to timeout.
https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Fdcos-diagnostics-new/detail/PR-201/13/pipeline#step-14-log-506