### PR TITLE
Revert "Mark dead service as unhaelthy"

### DIFF
--- a/api/properties_linux.go
+++ b/api/properties_linux.go
@@ -45,9 +45,5 @@ func (u *UnitPropertiesResponse) CheckUnitHealth() (dcos.Health, string, error) 
 		}
 	}
 
-	if u.ActiveState == "inactive" {
-		return dcos.Unhealthy, fmt.Sprintf("Unit %s is %s", u.ID, u.SubState), nil
-	}
-
 	return dcos.Healthy, "", nil
 }

--- a/api/properties_linux_test.go
+++ b/api/properties_linux_test.go
@@ -59,8 +59,8 @@ func TestUnitPropertiesResponse_CheckUnitHealth(t *testing.T) {
 		{
 			name:   "inactive service",
 			in:     UnitPropertiesResponse{ID: "dcos-telegraf.socket", LoadState: "loaded", ActiveState: "inactive", SubState: "dead"},
-			health: dcos.Unhealthy,
-			info:   "Unit dcos-telegraf.socket is dead",
+			health: dcos.Healthy,
+			info:   "",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Reverts dcos/dcos-diagnostics#202 for some reason this change prevent DC/OS tests to start https://github.com/dcos/dcos/pull/7681